### PR TITLE
feat: migrate Norway map to static snapshot with server-side clustering

### DIFF
--- a/.github/workflows/generate-points-snapshot.yml
+++ b/.github/workflows/generate-points-snapshot.yml
@@ -56,6 +56,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add assets/points.json
-          git diff --cached --quiet || git commit -m "chore: update assets/points.json [skip ci]"
+          git add assets/points.json assets/norway-points.json
+          git diff --cached --quiet || git commit -m "chore: update points snapshots [skip ci]"
           git push

--- a/js/norway-map.js
+++ b/js/norway-map.js
@@ -1,6 +1,7 @@
 // js/norway-map.js — Interactive planning map for the Norway trip
-// Loads points directly from Firestore (country=Norway), shows PMTiles route
-// overlays, point-type filter UI, fullscreen toggle.
+// Loads points from a static JSON snapshot (assets/norway-points.json) with
+// server-side clustering at zoom levels 3–7; shows PMTiles route overlays,
+// point-type filter UI, fullscreen toggle.
 
 // ── PMTiles protocol interceptor ────────────────────────────
 // Idempotent: shared with route-map.js; only installed once per page load.
@@ -42,7 +43,7 @@
   const POINT_ICON_ANCHOR  = [9, 9];
   const POINT_POPUP_ANCHOR = [0, -10];
 
-  // Norwegian planning point types — superset of Japan types for forward-compat
+  // Norwegian planning point types
   const POINT_TYPE_ICONS = {
     'Campsite': {
       color: '#27ae60',
@@ -177,7 +178,6 @@
     )
   };
 
-  // CyclOSM is more useful for Norway route planning
   baseLayers['CyclOSM (Cycling)'].addTo(map);
 
   const overlayLayers = {
@@ -252,6 +252,17 @@
   const pointTypeFilters = new Set();
   const _seenPointTypes = new Set();
 
+  // ── Snapshot state ──────────────────────────────────────────
+  let _pointsLoadStarted = false;
+  const NORWAY_SNAPSHOT_URL = 'assets/norway-points.json';
+  let snapshotRawPoints = null;
+  let serverClusterLevels = null;
+  let serverClusterLevelKeys = [];
+  let serverClusterLevelActiveKey = null;
+  let serverClusterDisableZoom = 8;
+  let _onZoomEndSnapshot = null;
+  let _batchGeneration = 0;
+
   function getAvailablePointTypes() {
     const available = new Set();
     points.forEach(p => available.add(p.type || 'Other'));
@@ -266,6 +277,16 @@
   map.on('moveend', function () {
     if (_moveEndTimer) clearTimeout(_moveEndTimer);
     _moveEndTimer = setTimeout(applyPointTypeFilters, 150);
+  });
+
+  // ── Zoom-based cluster switching ────────────────────────────
+  let _zoomEndTimer = null;
+  map.on('zoomend', function () {
+    if (_zoomEndTimer) clearTimeout(_zoomEndTimer);
+    _zoomEndTimer = setTimeout(function () {
+      _zoomEndTimer = null;
+      if (_onZoomEndSnapshot) _onZoomEndSnapshot(map.getZoom());
+    }, 150);
   });
 
   function applyPointTypeFilters() {
@@ -283,6 +304,39 @@
   }
 
   function createPointMarker(pointData) {
+    // Render cluster node (pre-aggregated by the snapshot generator)
+    const clusterMeta = pointData && pointData.metadata && pointData.metadata.__cluster;
+    const clusterCount = Number(clusterMeta && clusterMeta.count) || 0;
+    if (clusterCount > 1) {
+      const clusterClass = clusterCount > 100 ? 'marker-cluster-large'
+                         : clusterCount > 10  ? 'marker-cluster-medium'
+                         : 'marker-cluster-small';
+      const marker = L.marker([pointData.lat, pointData.lon], {
+        icon: L.divIcon({
+          html: '<div><span>' + clusterCount + '</span></div>',
+          className: 'marker-cluster ' + clusterClass,
+          iconSize: L.point(40, 40)
+        })
+      });
+      marker.bindPopup(function () {
+        const items = (clusterMeta && clusterMeta.items) || [];
+        let html = '<b>' + escapeHtml(pointData.name || 'Cluster') + '</b><br>'
+                 + '<span style="font-size:0.9em;color:#6c757d;">' + clusterCount + ' points</span>';
+        if (items.length > 0) {
+          html += '<ul style="margin:0.4em 0 0 1.1em;padding:0;max-height:180px;overflow:auto">';
+          items.forEach(function (item) {
+            const n = item && item.name ? item.name : 'Point';
+            const u = item && item.url ? String(item.url) : '';
+            html += '<li>' + (u ? '<a href="' + escapeAttr(u) + '" target="_blank" rel="noopener">' + escapeHtml(n) + '</a>' : escapeHtml(n)) + '</li>';
+          });
+          html += '</ul>';
+        }
+        return html;
+      });
+      return marker;
+    }
+
+    // Individual point marker
     const pointType = getPointType(pointData);
     const marker = L.marker([pointData.lat, pointData.lon], { icon: getPointIcon(pointType) });
     marker.bindPopup(function () {
@@ -310,8 +364,60 @@
     return marker;
   }
 
-  function addPointsBatch(dataArray) {
-    dataArray.forEach(function (d) {
+  // ── Snapshot helpers ────────────────────────────────────────
+
+  function normalizeSnapshotPoint(d) {
+    return {
+      name: d.name || 'Point',
+      lat: d.lat,
+      lon: d.lon,
+      url: d.url || null,
+      type: d.type || null,
+      metadata: d.metadata || {},
+      fileName: d.fileName || 'norway-points.json',
+      id: d.id || null
+    };
+  }
+
+  function normalizeServerClusterPoint(d) {
+    const pd = normalizeSnapshotPoint(d);
+    const count = Number(d && d.metadata && d.metadata.__cluster && d.metadata.__cluster.count || 0);
+    if (count > 1 && (!pd.metadata || !pd.metadata.__cluster)) {
+      pd.metadata = Object.assign({}, pd.metadata, {
+        __cluster: { count, items: Array.isArray(d.items) ? d.items : [] }
+      });
+    }
+    return pd;
+  }
+
+  function getServerClusterLevelKeyForZoom(zoom) {
+    if (!serverClusterLevelKeys.length || zoom >= serverClusterDisableZoom) return null;
+    let selected = serverClusterLevelKeys[0];
+    for (let i = 0; i < serverClusterLevelKeys.length; i++) {
+      const key = serverClusterLevelKeys[i];
+      if (key <= zoom) selected = key;
+      else break;
+    }
+    return String(selected);
+  }
+
+  function getSnapshotDisplayPointsForZoom(zoom) {
+    const levelKey = getServerClusterLevelKeyForZoom(zoom);
+    if (levelKey && serverClusterLevels && Array.isArray(serverClusterLevels[levelKey])) {
+      return { levelKey, points: serverClusterLevels[levelKey].map(normalizeServerClusterPoint) };
+    }
+    return { levelKey: null, points: (snapshotRawPoints || []).map(normalizeSnapshotPoint) };
+  }
+
+  function applySnapshotDisplayForZoom(zoom, force) {
+    if (!snapshotRawPoints) return;
+    const display = getSnapshotDisplayPointsForZoom(zoom);
+    if (!force && serverClusterLevelActiveKey === display.levelKey) return;
+    serverClusterLevelActiveKey = display.levelKey;
+    pointLayerGroup.clearLayers();
+    points.length = 0;
+    ++_batchGeneration;
+    display.points.forEach(function (d) {
       const pointType = getPointType(d);
       points.push({
         name: d.name || 'Point',
@@ -323,8 +429,10 @@
         marker: null
       });
     });
-    renderPointToggles();
+    scheduleRenderPointToggles();
   }
+
+  // ── Point type toggles ──────────────────────────────────────
 
   let _toggleTimer = null;
   function scheduleRenderPointToggles() {
@@ -473,92 +581,65 @@
     }
   }
 
-  // Safety timeout: dismiss loading overlay after 30 s
   const _safetyTimeout = setTimeout(dismissLoadingOverlay, 30000);
 
-  // ── Firebase: load Norway points from Firestore ─────────────
-  let db = null;
+  // ── Load Norway points from static snapshot ─────────────────
+  function loadNorwaySnapshot() {
+    if (_pointsLoadStarted) return;
+    _pointsLoadStarted = true;
 
-  function loadNorwayPoints() {
-    if (!db) { dismissLoadingOverlay(); return; }
-    db.collection('points')
-      .where('country', '==', 'Norway')
-      .get()
-      .then(function (snapshot) {
-        const batch = [];
-        snapshot.forEach(function (doc) {
-          const d = doc.data();
-          if (typeof d.lat !== 'number' || typeof d.lon !== 'number') return;
-          batch.push({
-            name:     d.name || 'Point',
-            lat:      d.lat,
-            lon:      d.lon,
-            url:      d.url || d.URL || null,
-            type:     d.type || (d.metadata && (d.metadata.Type || d.metadata.type)) || null,
-            metadata: d.metadata || {}
-          });
-        });
-        if (batch.length > 0) {
-          addPointsBatch(batch);
-          // Fit map to points if they're not near the default Norway center
-          const fg = L.featureGroup(
-            batch.map(function (p) { return L.marker([p.lat, p.lon]); })
-          );
+    fetch(NORWAY_SNAPSHOT_URL, { cache: 'default' })
+      .then(function (res) {
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data || !Array.isArray(data.points)) throw new Error('unrecognised snapshot format');
+        if (data.points.length === 0) throw new Error('empty snapshot');
+
+        snapshotRawPoints = data.points;
+
+        const disableZoom = data.clusterZoomRange && Number(data.clusterZoomRange.disableClusteringAtZoom);
+        serverClusterDisableZoom = Number.isFinite(disableZoom) ? disableZoom : 8;
+
+        if (data.clustersByZoom && typeof data.clustersByZoom === 'object') {
+          serverClusterLevels = data.clustersByZoom;
+          serverClusterLevelKeys = Object.keys(serverClusterLevels)
+            .map(function (k) { return Number(k); })
+            .filter(Number.isFinite)
+            .sort(function (a, b) { return a - b; });
+        } else {
+          serverClusterLevels = null;
+          serverClusterLevelKeys = [];
+        }
+
+        serverClusterLevelActiveKey = null;
+        applySnapshotDisplayForZoom(map.getZoom(), true);
+
+        if (serverClusterLevelKeys.length > 0) {
+          _onZoomEndSnapshot = function (zoom) { applySnapshotDisplayForZoom(zoom, false); };
+        }
+
+        // Fit map to a sample of the raw points so the view isn't dominated by
+        // a handful of z3 cluster centroids spanning the whole country.
+        const sample = snapshotRawPoints.slice(0, 200);
+        if (sample.length > 0) {
+          const fg = L.featureGroup(sample.map(function (p) { return L.marker([p.lat, p.lon]); }));
           map.fitBounds(fg.getBounds(), { padding: [40, 40], maxZoom: 12 });
         }
+
         clearTimeout(_safetyTimeout);
         dismissLoadingOverlay();
       })
       .catch(function (err) {
-        console.warn('Norway: could not load points from Firestore:', err && err.message || err);
+        console.warn('Norway: could not load snapshot:', err && err.message || err);
         clearTimeout(_safetyTimeout);
         dismissLoadingOverlay();
       });
   }
 
-  // ── Firebase init ───────────────────────────────────────────
-  function initFirebase() {
-    if (typeof FIREBASE_CONFIG === 'undefined' || !FIREBASE_CONFIG.apiKey || FIREBASE_CONFIG.apiKey === 'YOUR_API_KEY') {
-      console.log('NorwayMap: Firebase not configured — running in local-only mode.');
-      clearTimeout(_safetyTimeout);
-      dismissLoadingOverlay();
-      return;
-    }
-    try {
-      if (!firebase.apps.length) firebase.initializeApp(FIREBASE_CONFIG);
-      const _app = firebase.app();
-      const isIOS = (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream)
-                 || (/Macintosh/.test(navigator.userAgent) && navigator.maxTouchPoints > 1);
-
-      function _finishInit(settings) {
-        db = firebase.firestore();
-        if (settings) {
-          try { db.settings(settings); } catch (e) { /* already set */ }
-        }
-        loadNorwayPoints();
-      }
-
-      if (!isIOS) {
-        import('https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js')
-          .then(function (mod) {
-            try {
-              mod.initializeFirestore(_app, { localCache: mod.memoryLocalCache() });
-            } catch (e) { /* already initialised */ }
-            _finishInit();
-          })
-          .catch(function () { _finishInit(); });
-      } else {
-        _finishInit({ experimentalForceLongPolling: true });
-      }
-    } catch (err) {
-      console.error('Firebase init error:', err);
-      clearTimeout(_safetyTimeout);
-      dismissLoadingOverlay();
-    }
-  }
-
   // ── Initialise ──────────────────────────────────────────────
-  initFirebase();
+  loadNorwaySnapshot();
 
   if (typeof requestIdleCallback === 'function') {
     requestIdleCallback(initPMTilesLayer, { timeout: 1000 });

--- a/scripts/generate-points-snapshot.js
+++ b/scripts/generate-points-snapshot.js
@@ -72,18 +72,36 @@ function normalizePointType(rawType) {
   return type;
 }
 
+function normalizeNorwayPointType(rawType) {
+  const type = rawType ? String(rawType).trim() : '';
+  if (!type) return 'Other';
+  if (/camp/i.test(type))                                           return 'Campsite';
+  if (/roadside\s*station/i.test(type))                             return 'Roadside Station';
+  if (/must\s*see/i.test(type))                                     return 'Must See';
+  if (/hotel/i.test(type))                                          return 'Hotel';
+  if (/onsen/i.test(type))                                          return 'Onsen';
+  if (/dnt.+special|dnt.+code|frilufts/i.test(type))               return 'DNT Code Hut';
+  if (/dnt/i.test(type))                                            return 'DNT Hut';
+  if (/cave|rock.?shelter/i.test(type))                             return 'Cave';
+  if (/municipal|day.?trip/i.test(type))                            return 'Day Hut';
+  if (/rental/i.test(type))                                         return 'Rental';
+  if (/open.?shelter|lean.?to|shelter|hut|koie|hytte/i.test(type)) return 'Open Shelter';
+  return 'Other';
+}
+
 function getClusterCellSizeForZoom(zoom) {
   return BASE_CLUSTER_CELL_SIZE / Math.pow(2, Math.max(0, zoom - SERVER_CLUSTER_MIN_ZOOM));
 }
 
-function buildServerClustersForZoom(points, zoom) {
+function buildServerClustersForZoom(points, zoom, normalizeFn) {
+  const normalize = normalizeFn || normalizePointType;
   const cellSize = getClusterCellSizeForZoom(zoom);
   const buckets = new Map();
 
   for (const p of points) {
     if (typeof p.lat !== 'number' || typeof p.lon !== 'number') continue;
     const rawType = (p.metadata && (p.metadata.Type || p.metadata.type)) || p.type || '';
-    const type = normalizePointType(rawType);
+    const type = normalize(rawType);
     const latKey = Math.round(p.lat / cellSize);
     const lonKey = Math.round(p.lon / cellSize);
     const key = `${type}:${latKey}:${lonKey}`;
@@ -131,10 +149,10 @@ function buildServerClustersForZoom(points, zoom) {
   });
 }
 
-function buildServerClusterLevels(points) {
+function buildServerClusterLevels(points, normalizeFn) {
   const levels = {};
   for (let zoom = SERVER_CLUSTER_MIN_ZOOM; zoom <= SERVER_CLUSTER_MAX_ZOOM; zoom++) {
-    levels[String(zoom)] = buildServerClustersForZoom(points, zoom);
+    levels[String(zoom)] = buildServerClustersForZoom(points, zoom, normalizeFn);
   }
   return levels;
 }
@@ -165,6 +183,7 @@ async function main() {
         fileName: d.fileName || null,
         visited:  d.visited  || false,
         type:     d.type     || null,
+        country:  d.country  || null,
         uploadedAt: d.uploadedAt ? d.uploadedAt.toMillis() : null,
       });
     });
@@ -258,6 +277,53 @@ async function main() {
   }
 
   console.log(`Done. ${points.length} point(s) written to points/points.json (generatedAt: ${generatedAt}).`);
+
+  // ── Norway snapshot ───────────────────────────────────────────────────────────
+  const norwayPoints = points.filter(p => p.country === 'Norway');
+  console.log(`\nNorway points: ${norwayPoints.length}`);
+
+  if (norwayPoints.length > 0) {
+    const norwayClustersByZoom = buildServerClusterLevels(norwayPoints, normalizeNorwayPointType);
+    Object.keys(norwayClustersByZoom).forEach(zoom => {
+      console.log(`Norway server clusters @ z${zoom}: ${norwayClustersByZoom[zoom].length}`);
+    });
+
+    const norwayJson = JSON.stringify({
+      generatedAt,
+      points: norwayPoints,
+      clustersByZoom: norwayClustersByZoom,
+      clusterZoomRange: {
+        min: SERVER_CLUSTER_MIN_ZOOM,
+        max: SERVER_CLUSTER_MAX_ZOOM,
+        disableClusteringAtZoom: SERVER_CLUSTER_DISABLE_ZOOM
+      }
+    });
+    const norwayBuffer = Buffer.from(norwayJson, 'utf8');
+    console.log(`Norway snapshot size: ${(norwayBuffer.length / 1024).toFixed(1)} KB`);
+
+    const norwayLocalPath = path.join(__dirname, '..', 'assets', 'norway-points.json');
+    fs.writeFileSync(norwayLocalPath, norwayJson, 'utf8');
+    console.log(`Norway local snapshot written to ${norwayLocalPath}`);
+
+    console.log('Uploading points/norway-points.json to Firebase Storage...');
+    const norwayFile = bucket.file('points/norway-points.json');
+    await norwayFile.save(norwayBuffer, {
+      contentType: 'application/json',
+      metadata: { cacheControl: 'public, max-age=300' }
+    });
+    try {
+      await norwayFile.makePublic();
+      console.log('Norway file made publicly readable.');
+    } catch (err) {
+      console.warn(
+        'Could not set public ACL for Norway file (fine if uniform bucket-level access is enabled):\n',
+        err.message
+      );
+    }
+    console.log(`Norway done. ${norwayPoints.length} point(s) written.`);
+  } else {
+    console.log('No Norway points found — norway-points.json not written.');
+  }
 }
 
 main().catch(err => {


### PR DESCRIPTION
Replaces the live Firestore query on the Norway planning map with a
static JSON snapshot (assets/norway-points.json) pre-built by CI, using
the same server-side clustering pattern as the Japan map. At zoom < 8
pre-computed cluster nodes are shown (zoom levels 3–7); at zoom ≥ 8
individual typed markers appear. Combined with the existing viewport
culling and lazy marker creation, this eliminates the slow Firestore
load on page open and dramatically reduces DOM marker count at low zoom,
making pan/zoom fast on mobile.

- scripts/generate-points-snapshot.js: adds country field to Firestore
  fetch, adds normalizeNorwayPointType, makes buildServerClusterLevels
  accept an optional normalizeFn, generates assets/norway-points.json
- js/norway-map.js: loads from static snapshot, adds zoomend handler for
  cluster-level switching, adds cluster marker rendering
- .github/workflows/generate-points-snapshot.yml: commits norway-points.json

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LT74xrvTC5XbMpYjJSjekj