### PR TITLE
feat: migrate Denmark map to static snapshot

### DIFF
--- a/.github/workflows/generate-points-snapshot.yml
+++ b/.github/workflows/generate-points-snapshot.yml
@@ -56,6 +56,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add assets/points.json assets/norway-points.json
+          git add assets/points.json assets/norway-points.json assets/denmark-points.json
           git diff --cached --quiet || git commit -m "chore: update points snapshots [skip ci]"
           git push

--- a/js/denmark-map.js
+++ b/js/denmark-map.js
@@ -458,88 +458,36 @@
 
   const _safetyTimeout = setTimeout(dismissLoadingOverlay, 30000);
 
-  // ── Firebase: load Denmark points from Firestore ────────────
-  let db = null;
+  // ── Load Denmark points from static snapshot ────────────────
+  const DENMARK_SNAPSHOT_URL = 'assets/denmark-points.json';
 
-  function loadDenmarkPoints() {
-    if (!db) { dismissLoadingOverlay(); return; }
-    db.collection('points')
-      .where('country', '==', 'Denmark')
-      .get()
-      .then(function (snapshot) {
-        const batch = [];
-        snapshot.forEach(function (doc) {
-          const d = doc.data();
-          if (typeof d.lat !== 'number' || typeof d.lon !== 'number') return;
-          batch.push({
-            name:     d.name || 'Point',
-            lat:      d.lat,
-            lon:      d.lon,
-            url:      d.url || d.URL || null,
-            type:     d.type || (d.metadata && (d.metadata.Type || d.metadata.type)) || null,
-            metadata: d.metadata || {}
-          });
-        });
-        if (batch.length > 0) {
-          addPointsBatch(batch);
-          const fg = L.featureGroup(
-            batch.map(function (p) { return L.marker([p.lat, p.lon]); })
-          );
-          map.fitBounds(fg.getBounds(), { padding: [40, 40], maxZoom: 12 });
-        }
+  function loadDenmarkSnapshot() {
+    fetch(DENMARK_SNAPSHOT_URL, { cache: 'default' })
+      .then(function (res) {
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data || !Array.isArray(data.points)) throw new Error('unrecognised snapshot format');
+        if (data.points.length === 0) throw new Error('empty snapshot');
+
+        addPointsBatch(data.points);
+        const sample = data.points.slice(0, 200);
+        const fg = L.featureGroup(sample.map(function (p) { return L.marker([p.lat, p.lon]); }));
+        map.fitBounds(fg.getBounds(), { padding: [40, 40], maxZoom: 12 });
+
         clearTimeout(_safetyTimeout);
         dismissLoadingOverlay();
       })
       .catch(function (err) {
-        console.warn('Denmark: could not load points from Firestore:', err && err.message || err);
+        console.warn('Denmark: could not load snapshot:', err && err.message || err);
         clearTimeout(_safetyTimeout);
         dismissLoadingOverlay();
       });
   }
 
-  // ── Firebase init ───────────────────────────────────────────
-  function initFirebase() {
-    if (typeof FIREBASE_CONFIG === 'undefined' || !FIREBASE_CONFIG.apiKey || FIREBASE_CONFIG.apiKey === 'YOUR_API_KEY') {
-      console.log('DenmarkMap: Firebase not configured — running in local-only mode.');
-      clearTimeout(_safetyTimeout);
-      dismissLoadingOverlay();
-      return;
-    }
-    try {
-      if (!firebase.apps.length) firebase.initializeApp(FIREBASE_CONFIG);
-      const _app = firebase.app();
-      const isIOS = (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream)
-                 || (/Macintosh/.test(navigator.userAgent) && navigator.maxTouchPoints > 1);
-
-      function _finishInit(settings) {
-        db = firebase.firestore();
-        if (settings) {
-          try { db.settings(settings); } catch (e) { /* already set */ }
-        }
-        loadDenmarkPoints();
-      }
-
-      if (!isIOS) {
-        import('https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js')
-          .then(function (mod) {
-            try {
-              mod.initializeFirestore(_app, { localCache: mod.memoryLocalCache() });
-            } catch (e) { /* already initialised */ }
-            _finishInit();
-          })
-          .catch(function () { _finishInit(); });
-      } else {
-        _finishInit({ experimentalForceLongPolling: true });
-      }
-    } catch (err) {
-      console.error('Firebase init error:', err);
-      clearTimeout(_safetyTimeout);
-      dismissLoadingOverlay();
-    }
-  }
-
   // ── Initialise ──────────────────────────────────────────────
-  initFirebase();
+  loadDenmarkSnapshot();
 
   if (typeof requestIdleCallback === 'function') {
     requestIdleCallback(initPMTilesLayer, { timeout: 1000 });

--- a/planning-denmark.html
+++ b/planning-denmark.html
@@ -11,8 +11,6 @@
   <link rel="preconnect" href="https://unpkg.com" />
   <link rel="preconnect" href="https://server.arcgisonline.com" />
   <link rel="preconnect" href="https://www.gstatic.com" />
-  <link rel="preconnect" href="https://firebasestorage.googleapis.com" />
-  <link rel="dns-prefetch" href="https://firestore.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
   <!-- Leaflet -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
@@ -421,11 +419,6 @@
 </footer>
 
 <script src="js/main.js"></script>
-
-<!-- Firebase SDKs -->
-<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
-<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-<script src="assets/js/firebase-config.js"></script>
 
 <!-- Leaflet + PMTiles + VectorGrid -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"

--- a/scripts/generate-points-snapshot.js
+++ b/scripts/generate-points-snapshot.js
@@ -72,6 +72,22 @@ function normalizePointType(rawType) {
   return type;
 }
 
+function normalizeDenmarkPointType(rawType) {
+  const type = rawType ? String(rawType).trim() : '';
+  if (!type) return 'Other';
+  if (/^3071$|fri.?telt|wild.?camp/i.test(type))       return 'Wild Camping';
+  if (/camp/i.test(type))                               return 'Campsite';
+  if (/roadside\s*station/i.test(type))                 return 'Roadside Station';
+  if (/must\s*see/i.test(type))                         return 'Must See';
+  if (/hotel/i.test(type))                              return 'Hotel';
+  if (/^3012$|shelter/i.test(type))                     return 'Shelter';
+  if (/^3022$|kano|kajak|canoe|kayak/i.test(type))      return 'Canoe/Kayak Site';
+  if (/^3031$|teltplads|tent.?site/i.test(type))        return 'Tent Site';
+  if (/^3081$|hæng|hammock/i.test(type))                return 'Hammock Grove';
+  if (/^3091$|bålhytte|fire.?hut/i.test(type))          return 'Fire Hut';
+  return 'Other';
+}
+
 function normalizeNorwayPointType(rawType) {
   const type = rawType ? String(rawType).trim() : '';
   if (!type) return 'Other';
@@ -323,6 +339,53 @@ async function main() {
     console.log(`Norway done. ${norwayPoints.length} point(s) written.`);
   } else {
     console.log('No Norway points found — norway-points.json not written.');
+  }
+
+  // ── Denmark snapshot ──────────────────────────────────────────
+  const denmarkPoints = points.filter(p => p.country === 'Denmark');
+  console.log(`\nDenmark points: ${denmarkPoints.length}`);
+
+  if (denmarkPoints.length > 0) {
+    const denmarkClustersByZoom = buildServerClusterLevels(denmarkPoints, normalizeDenmarkPointType);
+    Object.keys(denmarkClustersByZoom).forEach(zoom => {
+      console.log(`Denmark server clusters @ z${zoom}: ${denmarkClustersByZoom[zoom].length}`);
+    });
+
+    const denmarkJson = JSON.stringify({
+      generatedAt,
+      points: denmarkPoints,
+      clustersByZoom: denmarkClustersByZoom,
+      clusterZoomRange: {
+        min: SERVER_CLUSTER_MIN_ZOOM,
+        max: SERVER_CLUSTER_MAX_ZOOM,
+        disableClusteringAtZoom: SERVER_CLUSTER_DISABLE_ZOOM
+      }
+    });
+    const denmarkBuffer = Buffer.from(denmarkJson, 'utf8');
+    console.log(`Denmark snapshot size: ${(denmarkBuffer.length / 1024).toFixed(1)} KB`);
+
+    const denmarkLocalPath = path.join(__dirname, '..', 'assets', 'denmark-points.json');
+    fs.writeFileSync(denmarkLocalPath, denmarkJson, 'utf8');
+    console.log(`Denmark local snapshot written to ${denmarkLocalPath}`);
+
+    console.log('Uploading points/denmark-points.json to Firebase Storage...');
+    const denmarkFile = bucket.file('points/denmark-points.json');
+    await denmarkFile.save(denmarkBuffer, {
+      contentType: 'application/json',
+      metadata: { cacheControl: 'public, max-age=300' }
+    });
+    try {
+      await denmarkFile.makePublic();
+      console.log('Denmark file made publicly readable.');
+    } catch (err) {
+      console.warn(
+        'Could not set public ACL for Denmark file (fine if uniform bucket-level access is enabled):\n',
+        err.message
+      );
+    }
+    console.log(`Denmark done. ${denmarkPoints.length} point(s) written.`);
+  } else {
+    console.log('No Denmark points found — denmark-points.json not written.');
   }
 }
 


### PR DESCRIPTION
Replaces the live Firestore query on the Denmark planning page with a static JSON snapshot (assets/denmark-points.json), matching the approach used by the Norway map since commit 4459378.

- planning-denmark.html: remove Firebase SDK script tags and preconnect hints
- js/denmark-map.js: replace initFirebase/loadDenmarkPoints (Firestore) with loadDenmarkSnapshot() that fetches assets/denmark-points.json
- scripts/generate-points-snapshot.js: add normalizeDenmarkPointType() and a Denmark section that filters, clusters (zoom 3-7), writes the local snapshot, and uploads to Firebase Storage
- .github/workflows/generate-points-snapshot.yml: include assets/denmark-points.json in the git add / commit step

Trigger the "Generate Points Snapshot" workflow manually to produce the initial assets/denmark-points.json before merging.