### PR TITLE
fix: retry with exponential backoff for Overpass 429/504 errors

### DIFF
--- a/.github/workflows/fetch-norway-facilities.yml
+++ b/.github/workflows/fetch-norway-facilities.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   fetch-facilities:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: write
 

--- a/.github/workflows/fetch-norway-facilities.yml
+++ b/.github/workflows/fetch-norway-facilities.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   fetch-facilities:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: write
 

--- a/scripts/fetch-norway-facilities.js
+++ b/scripts/fetch-norway-facilities.js
@@ -158,7 +158,7 @@ async function fetchQuery({ label, query }, retries = 4) {
     if (!retryable || attempt === retries) {
       throw new Error(`Overpass returned HTTP ${res.status} for ${label}: ${text.slice(0, 200)}`);
     }
-    const delay = Math.pow(2, attempt) * 5000; // 10s, 20s, 40s
+    const delay = Math.pow(2, attempt) * 15000; // 30s, 60s, 120s
     console.log(`  HTTP ${res.status} — retrying in ${delay / 1000}s…`);
     await sleep(delay);
   }
@@ -170,8 +170,8 @@ async function main() {
     const points = await fetchQuery(q);
     console.log(`  ${q.label}: ${points.length}`);
     allPoints.push(...points);
-    // Brief pause between requests to avoid hammering the public Overpass instance.
-    await sleep(3000);
+    // Pause between requests so Overpass can free up quota before the next query.
+    await sleep(30000);
   }
   const points = allPoints;
 

--- a/scripts/fetch-norway-facilities.js
+++ b/scripts/fetch-norway-facilities.js
@@ -133,23 +133,35 @@ function mapElement(element) {
   };
 }
 
-async function fetchQuery({ label, query }) {
-  console.log(`Querying Overpass for ${label}…`);
-  const res = await fetch(
-    OVERPASS_URL + '?data=' + encodeURIComponent(query),
-    { headers: { 'User-Agent': 'norway-facilities-fetcher/1.0 (github.com/m-yasutake)' } }
-  );
-  if (!res.ok) {
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// Retries on 429 / 5xx with exponential backoff. Overpass occasionally returns
+// 504 under load even for fast queries — retrying is the right response.
+async function fetchQuery({ label, query }, retries = 4) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    console.log(`Querying Overpass for ${label} (attempt ${attempt}/${retries})…`);
+    const res = await fetch(
+      OVERPASS_URL + '?data=' + encodeURIComponent(query),
+      { headers: { 'User-Agent': 'norway-facilities-fetcher/1.0 (github.com/m-yasutake)' } }
+    );
+    if (res.ok) {
+      const data = await res.json();
+      if (!Array.isArray(data.elements)) {
+        throw new Error(`Unexpected Overpass response format for ${label}`);
+      }
+      return data.elements
+        .filter(el => el.type === 'node' && typeof el.lat === 'number' && typeof el.lon === 'number')
+        .map(mapElement);
+    }
     const text = await res.text().catch(() => '');
-    throw new Error(`Overpass returned HTTP ${res.status} for ${label}: ${text.slice(0, 200)}`);
+    const retryable = res.status === 429 || res.status >= 500;
+    if (!retryable || attempt === retries) {
+      throw new Error(`Overpass returned HTTP ${res.status} for ${label}: ${text.slice(0, 200)}`);
+    }
+    const delay = Math.pow(2, attempt) * 5000; // 10s, 20s, 40s
+    console.log(`  HTTP ${res.status} — retrying in ${delay / 1000}s…`);
+    await sleep(delay);
   }
-  const data = await res.json();
-  if (!Array.isArray(data.elements)) {
-    throw new Error(`Unexpected Overpass response format for ${label}`);
-  }
-  return data.elements
-    .filter(el => el.type === 'node' && typeof el.lat === 'number' && typeof el.lon === 'number')
-    .map(mapElement);
 }
 
 async function main() {
@@ -158,6 +170,8 @@ async function main() {
     const points = await fetchQuery(q);
     console.log(`  ${q.label}: ${points.length}`);
     allPoints.push(...points);
+    // Brief pause between requests to avoid hammering the public Overpass instance.
+    await sleep(3000);
   }
   const points = allPoints;
 


### PR DESCRIPTION
## Summary

- Adds retry logic (up to 4 attempts) with exponential backoff (30s → 60s → 120s) for transient `429` and `5xx` responses from the Overpass API
- Increases the inter-query cooldown pause from 3s to 30s to reduce the chance of hitting the rate limit in the first place
- Bumps the workflow `timeout-minutes` from 20 → 60 to cover worst-case retry scenarios

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUHnNmcFJgTWC4k6w4eyGe)_