### PR TITLE
Gear page improvements: images fix, categories, move buttons, admin cleanup

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1285,15 +1285,6 @@
         <button class="gear-admin-btn cancel" id="gearCancelBtn" style="display:none">✕ Cancel</button>
       </div>
 
-      <!-- Weight summary (inline on admin page) -->
-      <div style="display:flex;gap:1.5rem;margin-bottom:1rem;flex-wrap:wrap">
-        <div style="background:var(--color-white);border:1px solid var(--color-gray-200);border-radius:var(--radius-md);padding:.75rem 1.25rem;box-shadow:var(--shadow-sm)">
-          <div style="font-size:.75rem;color:var(--color-gray-500);text-transform:uppercase;letter-spacing:.05em">Total Weight</div>
-          <div style="font-size:1.4rem;font-weight:700;color:var(--color-secondary)" id="weightTotal">—</div>
-          <div style="font-size:.72rem;color:var(--color-gray-500)">kg listed</div>
-        </div>
-      </div>
-
       <div id="gearContent">
         <p style="padding:2rem;color:var(--color-gray-600)">Loading gear list…</p>
       </div>
@@ -3343,50 +3334,50 @@ const GearManagerAdmin = (function () {
 
   const GEAR_DEFAULT = [
     { id: 'mika-rig', icon: '🚲', name: "Mika's Rig", order: 0, items: [
-      { id: 'mr1', name: 'Touring bike',          weight: '', notes: 'Steel frame, 700c wheels',     group: 'Bike'   },
-      { id: 'mr2', name: 'Rear rack',             weight: '', notes: '',                             group: 'Mounts' },
-      { id: 'mr3', name: 'Front rack',            weight: '', notes: '',                             group: 'Mounts' },
-      { id: 'mr4', name: 'Rear panniers (pair)',  weight: '', notes: 'Ortlieb Back-Roller Classic',  group: 'Bags'   },
-      { id: 'mr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller',         group: 'Bags'   },
-      { id: 'mr6', name: 'Handlebar bag',         weight: '', notes: 'Quick access for snacks & map',group: 'Bags'   },
-      { id: 'mr7', name: 'Frame bag',             weight: '', notes: 'Tools & spares',               group: 'Bags'   },
+      { id: 'mr1', name: 'Touring bike',          notes: 'Steel frame, 700c wheels',     group: 'Bike'   },
+      { id: 'mr2', name: 'Rear rack',             notes: '',                             group: 'Mounts' },
+      { id: 'mr3', name: 'Front rack',            notes: '',                             group: 'Mounts' },
+      { id: 'mr4', name: 'Rear panniers (pair)',  notes: 'Ortlieb Back-Roller Classic',  group: 'Bags'   },
+      { id: 'mr5', name: 'Front panniers (pair)', notes: 'Ortlieb Front-Roller',         group: 'Bags'   },
+      { id: 'mr6', name: 'Handlebar bag',         notes: 'Quick access for snacks & map',group: 'Bags'   },
+      { id: 'mr7', name: 'Frame bag',             notes: 'Tools & spares',               group: 'Bags'   },
     ]},
     { id: 'tom-rig', icon: '🚲', name: "Tom's Rig", order: 1, items: [
-      { id: 'tr1', name: 'Touring bike',          weight: '', notes: 'Steel frame, 700c wheels',     group: 'Bike'   },
-      { id: 'tr2', name: 'Rear rack',             weight: '', notes: '',                             group: 'Mounts' },
-      { id: 'tr3', name: 'Front rack',            weight: '', notes: '',                             group: 'Mounts' },
-      { id: 'tr4', name: 'Rear panniers (pair)',  weight: '', notes: 'Ortlieb Back-Roller Classic',  group: 'Bags'   },
-      { id: 'tr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller',         group: 'Bags'   },
-      { id: 'tr6', name: 'Handlebar bag',         weight: '', notes: 'Route notes and quick-access gear', group: 'Bags' },
-      { id: 'tr7', name: 'Frame bag',             weight: '', notes: 'Pump and repair essentials',   group: 'Bags'   },
+      { id: 'tr1', name: 'Touring bike',          notes: 'Steel frame, 700c wheels',     group: 'Bike'   },
+      { id: 'tr2', name: 'Rear rack',             notes: '',                             group: 'Mounts' },
+      { id: 'tr3', name: 'Front rack',            notes: '',                             group: 'Mounts' },
+      { id: 'tr4', name: 'Rear panniers (pair)',  notes: 'Ortlieb Back-Roller Classic',  group: 'Bags'   },
+      { id: 'tr5', name: 'Front panniers (pair)', notes: 'Ortlieb Front-Roller',         group: 'Bags'   },
+      { id: 'tr6', name: 'Handlebar bag',         notes: 'Route notes and quick-access gear', group: 'Bags' },
+      { id: 'tr7', name: 'Frame bag',             notes: 'Pump and repair essentials',   group: 'Bags'   },
     ]},
     { id: 'shelter-sleep', icon: '🛏️', name: 'Shelter & Sleep', order: 2, items: [
-      { id: 'ss1', name: 'Tent (2-person)',     weight: '', notes: 'Main shelter',           group: '' },
-      { id: 'ss2', name: 'Sleeping bags',       weight: '', notes: 'Down bags for cool nights', group: '' },
-      { id: 'ss3', name: 'Sleeping mats',       weight: '', notes: 'Compact inflatable mats',  group: '' },
+      { id: 'ss1', name: 'Tent (2-person)',     notes: 'Main shelter',           group: '' },
+      { id: 'ss2', name: 'Sleeping bags',       notes: 'Down bags for cool nights', group: '' },
+      { id: 'ss3', name: 'Sleeping mats',       notes: 'Compact inflatable mats',  group: '' },
     ]},
     { id: 'cooking-eating', icon: '🍳', name: 'Cooking & Eating', order: 3, items: [
-      { id: 'ce1', name: 'Cooking stove + fuel',     weight: '', notes: 'Primary cooking setup', group: '' },
-      { id: 'ce2', name: 'Cook pot + pan',           weight: '', notes: 'Simple camp cooking set', group: '' },
-      { id: 'ce3', name: 'Mugs, bowls and utensils', weight: '', notes: 'Shared meal kit', group: '' },
+      { id: 'ce1', name: 'Cooking stove + fuel',     notes: 'Primary cooking setup', group: '' },
+      { id: 'ce2', name: 'Cook pot + pan',           notes: 'Simple camp cooking set', group: '' },
+      { id: 'ce3', name: 'Mugs, bowls and utensils', notes: 'Shared meal kit', group: '' },
     ]},
     { id: 'clothing', icon: '👕', name: 'Clothing', order: 4, items: [
-      { id: 'cl1', name: 'Cycling jerseys (×3)', weight: '', notes: 'Merino wool preferred', group: '' },
-      { id: 'cl2', name: 'Bib shorts / shorts (×2)', weight: '', notes: '', group: '' },
-      { id: 'cl3', name: 'Rain jacket',          weight: '', notes: 'Lightweight packable', group: '' },
+      { id: 'cl1', name: 'Cycling jerseys (×3)', notes: 'Merino wool preferred', group: '' },
+      { id: 'cl2', name: 'Bib shorts / shorts (×2)', notes: '', group: '' },
+      { id: 'cl3', name: 'Rain jacket',          notes: 'Lightweight packable', group: '' },
     ]},
     { id: 'nav-tech', icon: '📡', name: 'Navigation & Tech', order: 5, items: [
-      { id: 'nt1', name: 'GPS device',  weight: '', notes: 'Garmin Edge', group: '' },
-      { id: 'nt2', name: 'Camera',      weight: '', notes: '',            group: '' },
-      { id: 'nt3', name: 'Laptop',      weight: '', notes: 'For blog & work on the road', group: '' },
+      { id: 'nt1', name: 'GPS device',  notes: 'Garmin Edge', group: '' },
+      { id: 'nt2', name: 'Camera',      notes: '',            group: '' },
+      { id: 'nt3', name: 'Laptop',      notes: 'For blog & work on the road', group: '' },
     ]},
     { id: 'bike-maintenance', icon: '🔧', name: 'Bike Maintenance', order: 6, items: [
-      { id: 'bm1', name: 'Repair kit & multi-tool', weight: '', notes: '', group: '' },
-      { id: 'bm2', name: 'Spare tubes (×4)',         weight: '', notes: '700×35c', group: '' },
+      { id: 'bm1', name: 'Repair kit & multi-tool', notes: '', group: '' },
+      { id: 'bm2', name: 'Spare tubes (×4)',         notes: '700×35c', group: '' },
     ]},
     { id: 'extras', icon: '✨', name: 'Extras & Luxuries', order: 7, items: [
-      { id: 'ex1', name: 'Coffee dripper',  weight: '', notes: '', group: '' },
-      { id: 'ex2', name: 'Small sketchbook', weight: '', notes: '', group: '' },
+      { id: 'ex1', name: 'Coffee dripper',  notes: '', group: '' },
+      { id: 'ex2', name: 'Small sketchbook', notes: '', group: '' },
     ]},
   ];
 
@@ -3436,20 +3427,6 @@ const GearManagerAdmin = (function () {
     return '<span class="gear-tag ' + cls + '">' + (who || 'Both') + '</span>';
   }
 
-  function parseWeight(w) {
-    const m = (w || '').match(/([\d.]+)\s*kg/i);
-    return m ? parseFloat(m[1]) : 0;
-  }
-
-  function updateWeightSummary(data) {
-    let total = 0;
-    data.forEach(cat => {
-      cat.items.forEach(item => { total += parseWeight(item.weight); });
-    });
-    const el = document.getElementById('weightTotal');
-    if (el) el.textContent = total > 0 ? total.toFixed(1) : '—';
-  }
-
   const RIG_IDS = new Set(['mika-rig', 'tom-rig']);
   const RIG_GROUPS = ['Bike', 'Mounts', 'Bags'];
 
@@ -3460,11 +3437,11 @@ const GearManagerAdmin = (function () {
     data.forEach(cat => {
       const cid = cat.id;
       const isRig = RIG_IDS.has(cid);
-      // rig edit: Item | Group | Weight | Notes | actions (5 cols)
-      // rig view: Item | Weight | Notes (3 cols, with group separators)
-      // other edit: Item | Weight | Notes | actions (4 cols)
-      // other view: Item | Weight | Notes (3 cols)
-      const colCount = editMode ? (isRig ? 5 : 4) : 3;
+      // rig edit: Item | Group | Notes | actions (4 cols)
+      // rig view: Item | Notes (2 cols, with group separators)
+      // other edit: Item | Notes | actions (3 cols)
+      // other view: Item | Notes (2 cols)
+      const colCount = editMode ? (isRig ? 4 : 3) : 2;
 
       html += '<div class="gear-category"' + (editMode ? ' data-editing="1"' : '') + ' data-cat-id="' + cid + '">';
       html += '<div class="gear-category-header">';
@@ -3475,7 +3452,7 @@ const GearManagerAdmin = (function () {
 
       let headerCols = '<th>Item</th>';
       if (editMode && isRig) headerCols += '<th>Group</th>';
-      headerCols += '<th>Weight</th><th>Notes</th>';
+      headerCols += '<th>Notes</th>';
       if (editMode) headerCols += '<th></th>';
 
       html += '<table class="gear-table"><thead><tr>' + headerCols + '</tr></thead><tbody>';
@@ -3495,7 +3472,6 @@ const GearManagerAdmin = (function () {
             ['', ...RIG_GROUPS].map(v => '<option value="' + v + '"' + (grp === v ? ' selected' : '') + '>' + (v || '—') + '</option>').join('') +
             '</select></td>';
         }
-        html += '<td data-label="Weight" class="gear-weight"' + (editMode ? ' contenteditable="true" data-field="weight"' : '') + '>' + (item.weight || '') + '</td>';
         html += '<td data-label="Notes" class="gear-notes"' + (editMode ? ' contenteditable="true" data-field="notes"' : '') + '>' + (item.notes || '') + '</td>';
         if (editMode) {
           html += '<td data-label="" style="white-space:nowrap">' +
@@ -3515,7 +3491,6 @@ const GearManagerAdmin = (function () {
       html += '<button class="gear-add-cat-btn" onclick="GearManagerAdmin.addCategory()">＋ Add category</button>';
     }
     content.innerHTML = html;
-    updateWeightSummary(data);
   }
 
   function collectFromDOM() {
@@ -3527,17 +3502,15 @@ const GearManagerAdmin = (function () {
       const name   = (header.querySelector('[data-field="name"]') || {}).textContent || '';
       const items  = [];
       catEl.querySelectorAll('tbody tr').forEach(row => {
-        const nameEl   = row.querySelector('[data-field="name"]');
-        const weightEl = row.querySelector('[data-field="weight"]');
-        const notesEl  = row.querySelector('[data-field="notes"]');
-        const groupEl  = row.querySelector('[data-field="group"]');
+        const nameEl  = row.querySelector('[data-field="name"]');
+        const notesEl = row.querySelector('[data-field="notes"]');
+        const groupEl = row.querySelector('[data-field="group"]');
         if (!nameEl) return;
         items.push({
-          id:     row.dataset.itemId || uid(),
-          name:   nameEl.textContent.trim(),
-          weight: weightEl ? weightEl.textContent.trim() : '',
-          notes:  notesEl  ? notesEl.textContent.trim()  : '',
-          group:  groupEl  ? groupEl.value               : '',
+          id:    row.dataset.itemId || uid(),
+          name:  nameEl.textContent.trim(),
+          notes: notesEl ? notesEl.textContent.trim() : '',
+          group: groupEl ? groupEl.value              : '',
         });
       });
       cats.push({ id: catId, icon: icon.trim(), name: name.trim(), items });
@@ -3650,7 +3623,7 @@ const GearManagerAdmin = (function () {
     addItem(catId) {
       _gearData = collectFromDOM();
       const cat = _gearData.find(c => c.id === catId);
-      if (cat) cat.items.push({ id: uid(), name: 'New item', weight: '', notes: '', group: '' });
+      if (cat) cat.items.push({ id: uid(), name: 'New item', notes: '', group: '' });
       renderGear(_gearData, true);
     },
     addCategory() {

--- a/admin.html
+++ b/admin.html
@@ -498,6 +498,19 @@
   .admin-gear-bar .gear-admin-btn.edit { background: var(--color-secondary); color: #fff; }
   .admin-gear-bar .gear-admin-btn.save { background: var(--color-primary); color: #fff; }
   .admin-gear-bar .gear-admin-btn.cancel { background: var(--color-gray-300); color: var(--color-gray-800); }
+  .gear-row-delete, .gear-row-move {
+    background: none; border: none; cursor: pointer;
+    font-size: 1rem; opacity: 0.5; padding: 0.2rem;
+    transition: opacity 0.15s;
+  }
+  .gear-row-delete:hover, .gear-row-move:hover { opacity: 1; }
+  .gear-row-move { font-size: 0.85rem; }
+  .gear-group-header td {
+    background: var(--color-gray-100);
+    font-weight: 700; font-size: 0.72rem;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--color-primary); padding: 0.4rem 1rem;
+  }
 
   /* ── Email composer ──────────────────────────────────── */
   .email-composer-card {
@@ -1236,18 +1249,8 @@
 
       <!-- Bike Links -->
       <div class="new-post-form" style="margin-bottom:1.5rem">
-        <h3 style="margin-bottom:1rem">🚲 Bike Links &amp; Photos</h3>
-        <p style="font-size:.85rem;color:var(--color-gray-500);margin-bottom:1rem">These links and photos appear at the top of the Gear page.</p>
-        <div class="form-row">
-          <div class="form-group">
-            <label>Mika's Bike URL</label>
-            <input type="url" id="bike-link-mika" class="form-control" placeholder="https://…" />
-          </div>
-          <div class="form-group">
-            <label>Tom's Bike URL</label>
-            <input type="url" id="bike-link-tom" class="form-control" placeholder="https://…" />
-          </div>
-        </div>
+        <h3 style="margin-bottom:1rem">🚲 Bike Photos</h3>
+        <p style="font-size:.85rem;color:var(--color-gray-500);margin-bottom:1rem">These photos appear at the top of the Gear page.</p>
         <div class="form-row">
           <div class="form-group">
             <label>Mika's Bike Photo</label>
@@ -1272,7 +1275,7 @@
             </div>
           </div>
         </div>
-        <button class="btn btn-primary" id="bike-links-save-btn" onclick="saveBikeLinks()">💾 Save Bike Links &amp; Photos</button>
+        <button class="btn btn-primary" id="bike-links-save-btn" onclick="saveBikeLinks()">💾 Save Bike Photos</button>
       </div>
 
       <div class="admin-gear-bar" id="gearAdminBar" style="display:none">
@@ -1285,14 +1288,9 @@
       <!-- Weight summary (inline on admin page) -->
       <div style="display:flex;gap:1.5rem;margin-bottom:1rem;flex-wrap:wrap">
         <div style="background:var(--color-white);border:1px solid var(--color-gray-200);border-radius:var(--radius-md);padding:.75rem 1.25rem;box-shadow:var(--shadow-sm)">
-          <div style="font-size:.75rem;color:var(--color-gray-500);text-transform:uppercase;letter-spacing:.05em">Mika</div>
-          <div style="font-size:1.4rem;font-weight:700;color:var(--color-secondary)" id="weightMika">—</div>
-          <div style="font-size:.72rem;color:var(--color-gray-500)">kg (loaded)</div>
-        </div>
-        <div style="background:var(--color-white);border:1px solid var(--color-gray-200);border-radius:var(--radius-md);padding:.75rem 1.25rem;box-shadow:var(--shadow-sm)">
-          <div style="font-size:.75rem;color:var(--color-gray-500);text-transform:uppercase;letter-spacing:.05em">Tom</div>
-          <div style="font-size:1.4rem;font-weight:700;color:var(--color-secondary)" id="weightTom">—</div>
-          <div style="font-size:.72rem;color:var(--color-gray-500)">kg (loaded)</div>
+          <div style="font-size:.75rem;color:var(--color-gray-500);text-transform:uppercase;letter-spacing:.05em">Total Weight</div>
+          <div style="font-size:1.4rem;font-weight:700;color:var(--color-secondary)" id="weightTotal">—</div>
+          <div style="font-size:.72rem;color:var(--color-gray-500)">kg listed</div>
         </div>
       </div>
 
@@ -3344,35 +3342,51 @@ const GearManagerAdmin = (function () {
   let _initialized = false;
 
   const GEAR_DEFAULT = [
-    { id: 'bikes-bags', icon: '🚲', name: 'Bikes & Bags', order: 0, items: [
-      { id: 'bb1', name: 'Touring bike (each)',   weight: '10.5 kg', who: 'Both', notes: 'Steel frame, 700c wheels' },
-      { id: 'bb2', name: 'Rear panniers (pair)',  weight: '1.4 kg',  who: 'Both', notes: 'Ortlieb Back-Roller Classic' },
-      { id: 'bb3', name: 'Front panniers (pair)', weight: '1.1 kg',  who: 'Both', notes: 'Ortlieb Front-Roller' },
-      { id: 'bb4', name: 'Handlebar bag',         weight: '0.4 kg',  who: 'Both', notes: 'Quick access for snacks & map' },
-      { id: 'bb5', name: 'Frame bag',             weight: '0.2 kg',  who: 'Both', notes: 'Tools & spares' },
+    { id: 'mika-rig', icon: '🚲', name: "Mika's Rig", order: 0, items: [
+      { id: 'mr1', name: 'Touring bike',          weight: '', notes: 'Steel frame, 700c wheels',     group: 'Bike'   },
+      { id: 'mr2', name: 'Rear rack',             weight: '', notes: '',                             group: 'Mounts' },
+      { id: 'mr3', name: 'Front rack',            weight: '', notes: '',                             group: 'Mounts' },
+      { id: 'mr4', name: 'Rear panniers (pair)',  weight: '', notes: 'Ortlieb Back-Roller Classic',  group: 'Bags'   },
+      { id: 'mr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller',         group: 'Bags'   },
+      { id: 'mr6', name: 'Handlebar bag',         weight: '', notes: 'Quick access for snacks & map',group: 'Bags'   },
+      { id: 'mr7', name: 'Frame bag',             weight: '', notes: 'Tools & spares',               group: 'Bags'   },
     ]},
-    { id: 'shelter-sleep', icon: '⛺', name: 'Shelter & Sleep', order: 1, items: [
-      { id: 'ss1', name: 'Tent (2-person)',       weight: '1.6 kg', who: 'Tom',  notes: 'MSR Hubba Hubba NX' },
-      { id: 'ss2', name: 'Sleeping bag (each)',   weight: '0.9 kg', who: 'Both', notes: 'Down, comfort to 5°C' },
-      { id: 'ss3', name: 'Sleeping mat (each)',   weight: '0.5 kg', who: 'Both', notes: 'Thermarest NeoAir' },
+    { id: 'tom-rig', icon: '🚲', name: "Tom's Rig", order: 1, items: [
+      { id: 'tr1', name: 'Touring bike',          weight: '', notes: 'Steel frame, 700c wheels',     group: 'Bike'   },
+      { id: 'tr2', name: 'Rear rack',             weight: '', notes: '',                             group: 'Mounts' },
+      { id: 'tr3', name: 'Front rack',            weight: '', notes: '',                             group: 'Mounts' },
+      { id: 'tr4', name: 'Rear panniers (pair)',  weight: '', notes: 'Ortlieb Back-Roller Classic',  group: 'Bags'   },
+      { id: 'tr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller',         group: 'Bags'   },
+      { id: 'tr6', name: 'Handlebar bag',         weight: '', notes: 'Route notes and quick-access gear', group: 'Bags' },
+      { id: 'tr7', name: 'Frame bag',             weight: '', notes: 'Pump and repair essentials',   group: 'Bags'   },
     ]},
-    { id: 'nav-tech', icon: '📡', name: 'Navigation & Tech', order: 2, items: [
-      { id: 'nt1', name: 'GPS device',           weight: '0.1 kg', who: 'Both', notes: 'Garmin Edge 530' },
-      { id: 'nt5', name: 'Camera + lenses',      weight: '1.2 kg', who: 'Mika', notes: 'Sony A6400 + 16-50 kit' },
-      { id: 'nt6', name: 'Laptop (shared)',      weight: '1.3 kg', who: 'Mika', notes: 'For blog & work on the road' },
+    { id: 'shelter-sleep', icon: '🛏️', name: 'Shelter & Sleep', order: 2, items: [
+      { id: 'ss1', name: 'Tent (2-person)',     weight: '', notes: 'Main shelter',           group: '' },
+      { id: 'ss2', name: 'Sleeping bags',       weight: '', notes: 'Down bags for cool nights', group: '' },
+      { id: 'ss3', name: 'Sleeping mats',       weight: '', notes: 'Compact inflatable mats',  group: '' },
     ]},
-    { id: 'bike-maintenance', icon: '🔧', name: 'Bike Maintenance', order: 3, items: [
-      { id: 'bm1', name: 'Repair kit & multi-tool', weight: '0.4 kg', who: 'Both', notes: '' },
-      { id: 'bm2', name: 'Spare tubes (×4)',         weight: '0.4 kg', who: 'Both', notes: '700×35c' },
+    { id: 'cooking-eating', icon: '🍳', name: 'Cooking & Eating', order: 3, items: [
+      { id: 'ce1', name: 'Cooking stove + fuel',     weight: '', notes: 'Primary cooking setup', group: '' },
+      { id: 'ce2', name: 'Cook pot + pan',           weight: '', notes: 'Simple camp cooking set', group: '' },
+      { id: 'ce3', name: 'Mugs, bowls and utensils', weight: '', notes: 'Shared meal kit', group: '' },
     ]},
-    { id: 'clothing', icon: '👕', name: 'Clothing (per person)', order: 4, items: [
-      { id: 'cl1', name: 'Cycling jerseys (×3)', weight: '0.4 kg', who: 'Both', notes: 'Merino wool preferred' },
-      { id: 'cl3', name: 'Rain jacket',          weight: '0.4 kg', who: 'Both', notes: 'Lightweight packable' },
+    { id: 'clothing', icon: '👕', name: 'Clothing', order: 4, items: [
+      { id: 'cl1', name: 'Cycling jerseys (×3)', weight: '', notes: 'Merino wool preferred', group: '' },
+      { id: 'cl2', name: 'Bib shorts / shorts (×2)', weight: '', notes: '', group: '' },
+      { id: 'cl3', name: 'Rain jacket',          weight: '', notes: 'Lightweight packable', group: '' },
     ]},
-    { id: 'safety-health', icon: '🩺', name: 'Safety & Health', order: 5, items: [
-      { id: 'sh1', name: 'Helmets (each)',              weight: '0.3 kg', who: 'Both', notes: 'MIPS rated' },
-      { id: 'sh2', name: 'Lights front + rear (each)', weight: '0.2 kg', who: 'Both', notes: 'Rechargeable' },
-      { id: 'sh4', name: 'First aid kit',               weight: '0.4 kg', who: 'Mika', notes: 'Compact travel kit' },
+    { id: 'nav-tech', icon: '📡', name: 'Navigation & Tech', order: 5, items: [
+      { id: 'nt1', name: 'GPS device',  weight: '', notes: 'Garmin Edge', group: '' },
+      { id: 'nt2', name: 'Camera',      weight: '', notes: '',            group: '' },
+      { id: 'nt3', name: 'Laptop',      weight: '', notes: 'For blog & work on the road', group: '' },
+    ]},
+    { id: 'bike-maintenance', icon: '🔧', name: 'Bike Maintenance', order: 6, items: [
+      { id: 'bm1', name: 'Repair kit & multi-tool', weight: '', notes: '', group: '' },
+      { id: 'bm2', name: 'Spare tubes (×4)',         weight: '', notes: '700×35c', group: '' },
+    ]},
+    { id: 'extras', icon: '✨', name: 'Extras & Luxuries', order: 7, items: [
+      { id: 'ex1', name: 'Coffee dripper',  weight: '', notes: '', group: '' },
+      { id: 'ex2', name: 'Small sketchbook', weight: '', notes: '', group: '' },
     ]},
   ];
 
@@ -3428,20 +3442,16 @@ const GearManagerAdmin = (function () {
   }
 
   function updateWeightSummary(data) {
-    let mika = 0, tom = 0;
+    let total = 0;
     data.forEach(cat => {
-      cat.items.forEach(item => {
-        const w = parseWeight(item.weight);
-        const who = (item.who || 'Both').toLowerCase();
-        if (who === 'mika' || who === 'both') mika += w;
-        if (who === 'tom'  || who === 'both') tom  += w;
-      });
+      cat.items.forEach(item => { total += parseWeight(item.weight); });
     });
-    const elMika = document.getElementById('weightMika');
-    const elTom  = document.getElementById('weightTom');
-    if (elMika) elMika.textContent = mika.toFixed(1);
-    if (elTom)  elTom.textContent  = tom.toFixed(1);
+    const el = document.getElementById('weightTotal');
+    if (el) el.textContent = total > 0 ? total.toFixed(1) : '—';
   }
+
+  const RIG_IDS = new Set(['mika-rig', 'tom-rig']);
+  const RIG_GROUPS = ['Bike', 'Mounts', 'Bags'];
 
   function renderGear(data, editMode) {
     const content = document.getElementById('gearContent');
@@ -3449,26 +3459,55 @@ const GearManagerAdmin = (function () {
     let html = '';
     data.forEach(cat => {
       const cid = cat.id;
+      const isRig = RIG_IDS.has(cid);
+      // rig edit: Item | Group | Weight | Notes | actions (5 cols)
+      // rig view: Item | Weight | Notes (3 cols, with group separators)
+      // other edit: Item | Weight | Notes | actions (4 cols)
+      // other view: Item | Weight | Notes (3 cols)
+      const colCount = editMode ? (isRig ? 5 : 4) : 3;
+
       html += '<div class="gear-category"' + (editMode ? ' data-editing="1"' : '') + ' data-cat-id="' + cid + '">';
       html += '<div class="gear-category-header">';
       html += '<span class="gear-category-icon"' + (editMode ? ' contenteditable="true" data-field="icon"' : '') + '>' + cat.icon + '</span>';
       html += '<h3' + (editMode ? ' contenteditable="true" data-field="name"' : '') + '>' + cat.name + '</h3>';
       if (editMode) html += '<button class="gear-cat-delete" onclick="GearManagerAdmin.deleteCategory(\'' + cid + '\')" title="Remove category">✕ Remove</button>';
       html += '</div>';
-      html += '<table class="gear-table"><thead><tr><th>Item</th><th>Weight</th><th>Who</th><th>Notes</th>' + (editMode ? '<th></th>' : '') + '</tr></thead><tbody>';
+
+      let headerCols = '<th>Item</th>';
+      if (editMode && isRig) headerCols += '<th>Group</th>';
+      headerCols += '<th>Weight</th><th>Notes</th>';
+      if (editMode) headerCols += '<th></th>';
+
+      html += '<table class="gear-table"><thead><tr>' + headerCols + '</tr></thead><tbody>';
+
+      let lastGroup = null;
       cat.items.forEach(item => {
         const iid = item.id;
+        const grp = item.group || '';
+        if (!editMode && isRig && grp && grp !== lastGroup) {
+          lastGroup = grp;
+          html += '<tr class="gear-group-header"><td colspan="' + colCount + '" class="gear-group-label">' + grp + '</td></tr>';
+        }
         html += '<tr data-item-id="' + iid + '">';
-        html += '<td data-label="Item"' + (editMode ? ' contenteditable="true" data-field="name"' : '') + '>' + item.name + '</td>';
-        html += '<td data-label="Weight" class="gear-weight"' + (editMode ? ' contenteditable="true" data-field="weight"' : '') + '>' + item.weight + '</td>';
-        html += '<td data-label="Who">' + whoTag(item.who || 'Both', editMode) + '</td>';
-        html += '<td data-label="Notes" class="gear-notes"' + (editMode ? ' contenteditable="true" data-field="notes"' : '') + '>' + item.notes + '</td>';
-        if (editMode) html += '<td data-label=""><button class="gear-row-delete" onclick="GearManagerAdmin.deleteItem(\'' + cid + '\',\'' + iid + '\')" title="Delete row">🗑</button></td>';
+        html += '<td data-label="Item"' + (editMode ? ' contenteditable="true" data-field="name"' : '') + '>' + (item.name || '') + '</td>';
+        if (editMode && isRig) {
+          html += '<td data-label="Group"><select class="gear-status-select" data-field="group">' +
+            ['', ...RIG_GROUPS].map(v => '<option value="' + v + '"' + (grp === v ? ' selected' : '') + '>' + (v || '—') + '</option>').join('') +
+            '</select></td>';
+        }
+        html += '<td data-label="Weight" class="gear-weight"' + (editMode ? ' contenteditable="true" data-field="weight"' : '') + '>' + (item.weight || '') + '</td>';
+        html += '<td data-label="Notes" class="gear-notes"' + (editMode ? ' contenteditable="true" data-field="notes"' : '') + '>' + (item.notes || '') + '</td>';
+        if (editMode) {
+          html += '<td data-label="" style="white-space:nowrap">' +
+            '<button class="gear-row-move" onclick="GearManagerAdmin.moveItemUp(\'' + cid + '\',\'' + iid + '\')" title="Move up">↑</button>' +
+            '<button class="gear-row-move" onclick="GearManagerAdmin.moveItemDown(\'' + cid + '\',\'' + iid + '\')" title="Move down">↓</button>' +
+            '<button class="gear-row-delete" onclick="GearManagerAdmin.deleteItem(\'' + cid + '\',\'' + iid + '\')" title="Delete row">🗑</button></td>';
+        }
         html += '</tr>';
       });
       html += '</tbody>';
       if (editMode) {
-        html += '<tfoot><tr><td colspan="5"><button class="gear-add-row-btn" onclick="GearManagerAdmin.addItem(\'' + cid + '\')">＋ Add item</button></td></tr></tfoot>';
+        html += '<tfoot><tr><td colspan="' + colCount + '"><button class="gear-add-row-btn" onclick="GearManagerAdmin.addItem(\'' + cid + '\')">＋ Add item</button></td></tr></tfoot>';
       }
       html += '</table></div>';
     });
@@ -3490,15 +3529,15 @@ const GearManagerAdmin = (function () {
       catEl.querySelectorAll('tbody tr').forEach(row => {
         const nameEl   = row.querySelector('[data-field="name"]');
         const weightEl = row.querySelector('[data-field="weight"]');
-        const whoEl    = row.querySelector('[data-field="who"]');
         const notesEl  = row.querySelector('[data-field="notes"]');
+        const groupEl  = row.querySelector('[data-field="group"]');
         if (!nameEl) return;
         items.push({
           id:     row.dataset.itemId || uid(),
           name:   nameEl.textContent.trim(),
           weight: weightEl ? weightEl.textContent.trim() : '',
-          who:    whoEl    ? whoEl.value                 : 'Both',
           notes:  notesEl  ? notesEl.textContent.trim()  : '',
+          group:  groupEl  ? groupEl.value               : '',
         });
       });
       cats.push({ id: catId, icon: icon.trim(), name: name.trim(), items });
@@ -3563,10 +3602,6 @@ const GearManagerAdmin = (function () {
         const doc = await _getAdminDb().collection('site_config').doc('gear').get();
         if (doc.exists) {
           const d = doc.data();
-          const mikaEl = document.getElementById('bike-link-mika');
-          const tomEl  = document.getElementById('bike-link-tom');
-          if (mikaEl) mikaEl.value = d.mikaBikeUrl || '';
-          if (tomEl)  tomEl.value  = d.tomBikeUrl  || '';
           // Load bike photos using DOM methods to avoid XSS
           if (d.mikaBikePhoto) {
             const inp = document.getElementById('bike-photo-mika');
@@ -3615,12 +3650,30 @@ const GearManagerAdmin = (function () {
     addItem(catId) {
       _gearData = collectFromDOM();
       const cat = _gearData.find(c => c.id === catId);
-      if (cat) cat.items.push({ id: uid(), name: 'New item', weight: '0.0 kg', who: 'Both', notes: '' });
+      if (cat) cat.items.push({ id: uid(), name: 'New item', weight: '', notes: '', group: '' });
       renderGear(_gearData, true);
     },
     addCategory() {
       _gearData = collectFromDOM();
       _gearData.push({ id: uid(), icon: '📦', name: 'New Category', order: _gearData.length, items: [] });
+      renderGear(_gearData, true);
+    },
+    moveItemUp(catId, itemId) {
+      _gearData = collectFromDOM();
+      const cat = _gearData.find(c => c.id === catId);
+      if (!cat) return;
+      const idx = cat.items.findIndex(i => i.id === itemId);
+      if (idx <= 0) return;
+      [cat.items[idx - 1], cat.items[idx]] = [cat.items[idx], cat.items[idx - 1]];
+      renderGear(_gearData, true);
+    },
+    moveItemDown(catId, itemId) {
+      _gearData = collectFromDOM();
+      const cat = _gearData.find(c => c.id === catId);
+      if (!cat) return;
+      const idx = cat.items.findIndex(i => i.id === itemId);
+      if (idx < 0 || idx >= cat.items.length - 1) return;
+      [cat.items[idx + 1], cat.items[idx]] = [cat.items[idx], cat.items[idx + 1]];
       renderGear(_gearData, true);
     },
   };
@@ -4800,23 +4853,20 @@ document.addEventListener('DOMContentLoaded', () => {
 <script>
 // ── Bike Links Admin ──────────────────────────────────────────
 async function saveBikeLinks() {
-  const mikaUrl   = (document.getElementById('bike-link-mika')  || {}).value || '';
-  const tomUrl    = (document.getElementById('bike-link-tom')   || {}).value || '';
   const mikaPhoto = (document.getElementById('bike-photo-mika') || {}).value || '';
   const tomPhoto  = (document.getElementById('bike-photo-tom')  || {}).value || '';
   const btn = document.getElementById('bike-links-save-btn');
   if (btn) { btn.disabled = true; btn.textContent = '⏳ Saving…'; }
   try {
     await _getAdminDb().collection('site_config').doc('gear').set(
-      { mikaBikeUrl: mikaUrl.trim(), tomBikeUrl: tomUrl.trim(),
-        mikaBikePhoto: mikaPhoto.trim(), tomBikePhoto: tomPhoto.trim() },
+      { mikaBikePhoto: mikaPhoto.trim(), tomBikePhoto: tomPhoto.trim() },
       { merge: true }
     );
-    TomikaBikes.showToast('Bike links & photos saved!', 'success');
+    TomikaBikes.showToast('Bike photos saved!', 'success');
   } catch (e) {
     TomikaBikes.showToast('Save failed: ' + e.message, 'error');
   } finally {
-    if (btn) { btn.disabled = false; btn.textContent = '💾 Save Bike Links & Photos'; }
+    if (btn) { btn.disabled = false; btn.textContent = '💾 Save Bike Photos'; }
   }
 }
 

--- a/gear.html
+++ b/gear.html
@@ -148,7 +148,7 @@
       padding: 0 3px;
       cursor: text;
     }
-    .gear-row-delete {
+    .gear-row-delete, .gear-row-move {
       background: none;
       border: none;
       cursor: pointer;
@@ -157,7 +157,17 @@
       padding: 0.2rem;
       transition: opacity 0.15s;
     }
-    .gear-row-delete:hover { opacity: 1; }
+    .gear-row-delete:hover, .gear-row-move:hover { opacity: 1; }
+    .gear-row-move { font-size: 0.85rem; }
+    .gear-group-header td {
+      background: var(--color-gray-100);
+      font-weight: 700;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-primary);
+      padding: 0.4rem 1rem;
+    }
     .gear-cat-delete {
       margin-left: auto;
       background: rgba(255,255,255,0.2);
@@ -422,30 +432,50 @@
   // ── Default / seed data ──────────────────────────────────
   const GEAR_DEFAULT = [
     { id: 'mika-rig', icon: '🚲', name: "Mika's Rig", order: 0, items: [
-      { id: 'mr1', name: 'Touring bike', notes: 'Steel frame, 700c wheels' },
-      { id: 'mr2', name: 'Rear panniers (pair)', notes: 'Ortlieb Back-Roller Classic' },
-      { id: 'mr3', name: 'Front panniers (pair)', notes: 'Ortlieb Front-Roller' },
-      { id: 'mr4', name: 'Handlebar bag', notes: 'Quick access for camera and snacks' },
-      { id: 'mr5', name: 'Frame bag', notes: 'Tools and spares' },
+      { id: 'mr1', name: 'Touring bike', weight: '', notes: 'Steel frame, 700c wheels', group: 'Bike' },
+      { id: 'mr2', name: 'Rear rack', weight: '', notes: '', group: 'Mounts' },
+      { id: 'mr3', name: 'Front rack', weight: '', notes: '', group: 'Mounts' },
+      { id: 'mr4', name: 'Rear panniers (pair)', weight: '', notes: 'Ortlieb Back-Roller Classic', group: 'Bags' },
+      { id: 'mr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller', group: 'Bags' },
+      { id: 'mr6', name: 'Handlebar bag', weight: '', notes: 'Quick access for camera and snacks', group: 'Bags' },
+      { id: 'mr7', name: 'Frame bag', weight: '', notes: 'Tools and spares', group: 'Bags' },
     ]},
     { id: 'tom-rig', icon: '🚲', name: "Tom's Rig", order: 1, items: [
-      { id: 'tr1', name: 'Touring bike', notes: 'Steel frame, 700c wheels' },
-      { id: 'tr2', name: 'Rear panniers (pair)', notes: 'Ortlieb Back-Roller Classic' },
-      { id: 'tr3', name: 'Front panniers (pair)', notes: 'Ortlieb Front-Roller' },
-      { id: 'tr4', name: 'Handlebar bag', notes: 'Route notes and quick-access gear' },
-      { id: 'tr5', name: 'Frame bag', notes: 'Pump and repair essentials' },
+      { id: 'tr1', name: 'Touring bike', weight: '', notes: 'Steel frame, 700c wheels', group: 'Bike' },
+      { id: 'tr2', name: 'Rear rack', weight: '', notes: '', group: 'Mounts' },
+      { id: 'tr3', name: 'Front rack', weight: '', notes: '', group: 'Mounts' },
+      { id: 'tr4', name: 'Rear panniers (pair)', weight: '', notes: 'Ortlieb Back-Roller Classic', group: 'Bags' },
+      { id: 'tr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller', group: 'Bags' },
+      { id: 'tr6', name: 'Handlebar bag', weight: '', notes: 'Route notes and quick-access gear', group: 'Bags' },
+      { id: 'tr7', name: 'Frame bag', weight: '', notes: 'Pump and repair essentials', group: 'Bags' },
     ]},
-    { id: 'necessary-items', icon: '⛺', name: 'Necessary Items', order: 2, items: [
-      { id: 'ni1', name: 'Tent (2-person)', notes: 'Main shelter' },
-      { id: 'ni2', name: 'Sleeping bags', notes: 'Down bags for cool nights' },
-      { id: 'ni3', name: 'Sleeping mats', notes: 'Compact inflatable mats' },
-      { id: 'ni4', name: 'Cooking stove + fuel', notes: 'Primary cooking setup' },
-      { id: 'ni5', name: 'Cook pot + pan', notes: 'Simple camp cooking set' },
-      { id: 'ni6', name: 'Mugs, bowls and utensils', notes: 'Shared meal kit' },
+    { id: 'shelter-sleep', icon: '🛏️', name: 'Shelter & Sleep', order: 2, items: [
+      { id: 'ss1', name: 'Tent (2-person)', weight: '', notes: 'Main shelter', group: '' },
+      { id: 'ss2', name: 'Sleeping bags', weight: '', notes: 'Down bags for cool nights', group: '' },
+      { id: 'ss3', name: 'Sleeping mats', weight: '', notes: 'Compact inflatable mats', group: '' },
     ]},
-    { id: 'unnecessary-items', icon: '🎁', name: 'Unnecessary Items', order: 3, items: [
-      { id: 'ui1', name: 'Coffee dripper', notes: 'Tom' },
-      { id: 'ui2', name: 'Small sketchbook', notes: 'Mika' },
+    { id: 'cooking-eating', icon: '🍳', name: 'Cooking & Eating', order: 3, items: [
+      { id: 'ce1', name: 'Cooking stove + fuel', weight: '', notes: 'Primary cooking setup', group: '' },
+      { id: 'ce2', name: 'Cook pot + pan', weight: '', notes: 'Simple camp cooking set', group: '' },
+      { id: 'ce3', name: 'Mugs, bowls and utensils', weight: '', notes: 'Shared meal kit', group: '' },
+    ]},
+    { id: 'clothing', icon: '👕', name: 'Clothing', order: 4, items: [
+      { id: 'cl1', name: 'Cycling jerseys (×3)', weight: '', notes: 'Merino wool preferred', group: '' },
+      { id: 'cl2', name: 'Bib shorts / shorts (×2)', weight: '', notes: '', group: '' },
+      { id: 'cl3', name: 'Rain jacket', weight: '', notes: 'Lightweight packable', group: '' },
+    ]},
+    { id: 'nav-tech', icon: '📡', name: 'Navigation & Tech', order: 5, items: [
+      { id: 'nt1', name: 'GPS device', weight: '', notes: 'Garmin Edge', group: '' },
+      { id: 'nt2', name: 'Camera', weight: '', notes: '', group: '' },
+      { id: 'nt3', name: 'Laptop', weight: '', notes: 'For blog & work on the road', group: '' },
+    ]},
+    { id: 'bike-maintenance', icon: '🔧', name: 'Bike Maintenance', order: 6, items: [
+      { id: 'bm1', name: 'Repair kit & multi-tool', weight: '', notes: '', group: '' },
+      { id: 'bm2', name: 'Spare tubes (×4)', weight: '', notes: '700×35c', group: '' },
+    ]},
+    { id: 'extras', icon: '✨', name: 'Extras & Luxuries', order: 7, items: [
+      { id: 'ex1', name: 'Coffee dripper', weight: '', notes: '', group: '' },
+      { id: 'ex2', name: 'Small sketchbook', weight: '', notes: '', group: '' },
     ]},
   ];
 
@@ -488,8 +518,17 @@
   }
 
   // ── Rendering ─────────────────────────────────────────────
+  const RIG_IDS = new Set(['mika-rig', 'tom-rig']);
+
   function renderCategory(cat, editMode, includeHeader = true) {
     const cid = cat.id;
+    const isRig = RIG_IDS.has(cid);
+    // rig edit mode: Item | Group | Notes | actions
+    // rig view mode: Item | Notes  (with group separator rows)
+    // other edit:   Item | Notes | actions
+    // other view:   Item | Notes
+    const colCount = editMode ? (isRig ? 4 : 3) : 2;
+
     let html = '<div class="gear-category"' + (editMode ? ' data-editing="1"' : '') + ' data-cat-id="' + cid + '">';
     if (includeHeader) {
       html += '<div class="gear-category-header">';
@@ -498,19 +537,42 @@
       if (editMode) html += '<button class="gear-cat-delete" onclick="GearManager.deleteCategory(\'' + cid + '\')" title="Remove category">✕ Remove</button>';
       html += '</div>';
     }
-    html += '<table class="gear-table"><thead><tr><th>Item</th><th>Notes</th>' + (editMode ? '<th></th>' : '') + '</tr></thead><tbody>';
+
+    let headerCols = '<th>Item</th>';
+    if (editMode && isRig) headerCols += '<th>Group</th>';
+    headerCols += '<th>Notes</th>';
+    if (editMode) headerCols += '<th></th>';
+
+    html += '<table class="gear-table"><thead><tr>' + headerCols + '</tr></thead><tbody>';
+
+    const RIG_GROUPS = ['Bike', 'Mounts', 'Bags'];
+    let lastGroup = null;
     cat.items.forEach(item => {
       const iid = item.id;
+      const grp = item.group || '';
+      if (!editMode && isRig && grp && grp !== lastGroup) {
+        lastGroup = grp;
+        html += '<tr class="gear-group-header"><td colspan="' + colCount + '" class="gear-group-label">' + grp + '</td></tr>';
+      }
       html += '<tr data-item-id="' + iid + '">';
       html += '<td data-label="Item"' + (editMode ? ' contenteditable="true" data-field="name"' : '') + '>' + (item.name || '') + '</td>';
+      if (editMode && isRig) {
+        html += '<td data-label="Group"><select class="gear-status-select" data-field="group">' +
+          ['', ...RIG_GROUPS].map(v => '<option value="' + v + '"' + (grp === v ? ' selected' : '') + '>' + (v || '—') + '</option>').join('') +
+          '</select></td>';
+      }
       html += '<td data-label="Notes" class="gear-notes"' + (editMode ? ' contenteditable="true" data-field="notes"' : '') + '>' + (item.notes || '') + '</td>';
-      if (editMode) html += '<td data-label=""><button class="gear-row-delete" onclick="GearManager.deleteItem(\'' + cid + '\',\'' + iid + '\')" title="Delete row">🗑</button></td>';
+      if (editMode) {
+        html += '<td data-label="" style="white-space:nowrap">' +
+          '<button class="gear-row-move" onclick="GearManager.moveItemUp(\'' + cid + '\',\'' + iid + '\')" title="Move up">↑</button>' +
+          '<button class="gear-row-move" onclick="GearManager.moveItemDown(\'' + cid + '\',\'' + iid + '\')" title="Move down">↓</button>' +
+          '<button class="gear-row-delete" onclick="GearManager.deleteItem(\'' + cid + '\',\'' + iid + '\')" title="Delete row">🗑</button></td>';
+      }
       html += '</tr>';
     });
     html += '</tbody>';
     if (editMode) {
-      const colSpan = editMode ? 3 : 2;
-      html += '<tfoot><tr><td colspan="' + colSpan + '"><button class="gear-add-row-btn" onclick="GearManager.addItem(\'' + cid + '\')">＋ Add item</button></td></tr></tfoot>';
+      html += '<tfoot><tr><td colspan="' + colCount + '"><button class="gear-add-row-btn" onclick="GearManager.addItem(\'' + cid + '\')">＋ Add item</button></td></tr></tfoot>';
     }
     html += '</table></div>';
     return html;
@@ -554,11 +616,14 @@
       catEl.querySelectorAll('tbody tr').forEach(row => {
         const nameEl   = row.querySelector('[data-field="name"]');
         const notesEl  = row.querySelector('[data-field="notes"]');
+        const groupEl  = row.querySelector('[data-field="group"]');
         if (!nameEl) return;
         items.push({
           id:     row.dataset.itemId || uid(),
           name:   nameEl.textContent.trim(),
-          notes:  notesEl  ? notesEl.textContent.trim()  : '',
+          notes:  notesEl ? notesEl.textContent.trim() : '',
+          weight: '',
+          group:  groupEl ? groupEl.value : '',
         });
       });
       cats.push({ id: catId, icon: icon.trim(), name: name.trim(), items });
@@ -582,12 +647,30 @@
     addItem(catId) {
       _gearData = collectFromDOM();
       const cat = _gearData.find(c => c.id === catId);
-      if (cat) cat.items.push({ id: uid(), name: 'New item', notes: '' });
+      if (cat) cat.items.push({ id: uid(), name: 'New item', weight: '', notes: '', group: '' });
       renderGear(_gearData, true);
     },
     addCategory() {
       _gearData = collectFromDOM();
       _gearData.push({ id: uid(), icon: '📦', name: 'New Category', order: _gearData.length, items: [] });
+      renderGear(_gearData, true);
+    },
+    moveItemUp(catId, itemId) {
+      _gearData = collectFromDOM();
+      const cat = _gearData.find(c => c.id === catId);
+      if (!cat) return;
+      const idx = cat.items.findIndex(i => i.id === itemId);
+      if (idx <= 0) return;
+      [cat.items[idx - 1], cat.items[idx]] = [cat.items[idx], cat.items[idx - 1]];
+      renderGear(_gearData, true);
+    },
+    moveItemDown(catId, itemId) {
+      _gearData = collectFromDOM();
+      const cat = _gearData.find(c => c.id === catId);
+      if (!cat) return;
+      const idx = cat.items.findIndex(i => i.id === itemId);
+      if (idx < 0 || idx >= cat.items.length - 1) return;
+      [cat.items[idx + 1], cat.items[idx]] = [cat.items[idx], cat.items[idx + 1]];
       renderGear(_gearData, true);
     },
   };
@@ -652,13 +735,14 @@
   // ── Init ──────────────────────────────────────────────────
   function isRevampedShape(data) {
     const ids = new Set((data || []).map(cat => cat.id));
-    return ids.has('mika-rig') && ids.has('tom-rig') && ids.has('necessary-items') && ids.has('unnecessary-items');
+    return ids.has('mika-rig') && ids.has('tom-rig');
   }
 
   async function init() {
     try {
       await window.TomikaBikes.ensureFirebaseAuth();
       await ensureFirestore();
+      await loadBikeLinks();
       const data = await fetchFromFirestore();
       _gearData = (data && isRevampedShape(data)) ? data : GEAR_DEFAULT;
       if (!data || !isRevampedShape(data)) await saveToFirestore(_gearData);
@@ -667,7 +751,6 @@
       _gearData = GEAR_DEFAULT;
     }
     renderGear(_gearData, false);
-    loadBikeLinks();
     watchAdminState();
   }
 

--- a/gear.html
+++ b/gear.html
@@ -432,50 +432,50 @@
   // ── Default / seed data ──────────────────────────────────
   const GEAR_DEFAULT = [
     { id: 'mika-rig', icon: '🚲', name: "Mika's Rig", order: 0, items: [
-      { id: 'mr1', name: 'Touring bike', weight: '', notes: 'Steel frame, 700c wheels', group: 'Bike' },
-      { id: 'mr2', name: 'Rear rack', weight: '', notes: '', group: 'Mounts' },
-      { id: 'mr3', name: 'Front rack', weight: '', notes: '', group: 'Mounts' },
-      { id: 'mr4', name: 'Rear panniers (pair)', weight: '', notes: 'Ortlieb Back-Roller Classic', group: 'Bags' },
-      { id: 'mr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller', group: 'Bags' },
-      { id: 'mr6', name: 'Handlebar bag', weight: '', notes: 'Quick access for camera and snacks', group: 'Bags' },
-      { id: 'mr7', name: 'Frame bag', weight: '', notes: 'Tools and spares', group: 'Bags' },
+      { id: 'mr1', name: 'Touring bike', notes: 'Steel frame, 700c wheels', group: 'Bike' },
+      { id: 'mr2', name: 'Rear rack', notes: '', group: 'Mounts' },
+      { id: 'mr3', name: 'Front rack', notes: '', group: 'Mounts' },
+      { id: 'mr4', name: 'Rear panniers (pair)', notes: 'Ortlieb Back-Roller Classic', group: 'Bags' },
+      { id: 'mr5', name: 'Front panniers (pair)', notes: 'Ortlieb Front-Roller', group: 'Bags' },
+      { id: 'mr6', name: 'Handlebar bag', notes: 'Quick access for camera and snacks', group: 'Bags' },
+      { id: 'mr7', name: 'Frame bag', notes: 'Tools and spares', group: 'Bags' },
     ]},
     { id: 'tom-rig', icon: '🚲', name: "Tom's Rig", order: 1, items: [
-      { id: 'tr1', name: 'Touring bike', weight: '', notes: 'Steel frame, 700c wheels', group: 'Bike' },
-      { id: 'tr2', name: 'Rear rack', weight: '', notes: '', group: 'Mounts' },
-      { id: 'tr3', name: 'Front rack', weight: '', notes: '', group: 'Mounts' },
-      { id: 'tr4', name: 'Rear panniers (pair)', weight: '', notes: 'Ortlieb Back-Roller Classic', group: 'Bags' },
-      { id: 'tr5', name: 'Front panniers (pair)', weight: '', notes: 'Ortlieb Front-Roller', group: 'Bags' },
-      { id: 'tr6', name: 'Handlebar bag', weight: '', notes: 'Route notes and quick-access gear', group: 'Bags' },
-      { id: 'tr7', name: 'Frame bag', weight: '', notes: 'Pump and repair essentials', group: 'Bags' },
+      { id: 'tr1', name: 'Touring bike', notes: 'Steel frame, 700c wheels', group: 'Bike' },
+      { id: 'tr2', name: 'Rear rack', notes: '', group: 'Mounts' },
+      { id: 'tr3', name: 'Front rack', notes: '', group: 'Mounts' },
+      { id: 'tr4', name: 'Rear panniers (pair)', notes: 'Ortlieb Back-Roller Classic', group: 'Bags' },
+      { id: 'tr5', name: 'Front panniers (pair)', notes: 'Ortlieb Front-Roller', group: 'Bags' },
+      { id: 'tr6', name: 'Handlebar bag', notes: 'Route notes and quick-access gear', group: 'Bags' },
+      { id: 'tr7', name: 'Frame bag', notes: 'Pump and repair essentials', group: 'Bags' },
     ]},
     { id: 'shelter-sleep', icon: '🛏️', name: 'Shelter & Sleep', order: 2, items: [
-      { id: 'ss1', name: 'Tent (2-person)', weight: '', notes: 'Main shelter', group: '' },
-      { id: 'ss2', name: 'Sleeping bags', weight: '', notes: 'Down bags for cool nights', group: '' },
-      { id: 'ss3', name: 'Sleeping mats', weight: '', notes: 'Compact inflatable mats', group: '' },
+      { id: 'ss1', name: 'Tent (2-person)', notes: 'Main shelter', group: '' },
+      { id: 'ss2', name: 'Sleeping bags', notes: 'Down bags for cool nights', group: '' },
+      { id: 'ss3', name: 'Sleeping mats', notes: 'Compact inflatable mats', group: '' },
     ]},
     { id: 'cooking-eating', icon: '🍳', name: 'Cooking & Eating', order: 3, items: [
-      { id: 'ce1', name: 'Cooking stove + fuel', weight: '', notes: 'Primary cooking setup', group: '' },
-      { id: 'ce2', name: 'Cook pot + pan', weight: '', notes: 'Simple camp cooking set', group: '' },
-      { id: 'ce3', name: 'Mugs, bowls and utensils', weight: '', notes: 'Shared meal kit', group: '' },
+      { id: 'ce1', name: 'Cooking stove + fuel', notes: 'Primary cooking setup', group: '' },
+      { id: 'ce2', name: 'Cook pot + pan', notes: 'Simple camp cooking set', group: '' },
+      { id: 'ce3', name: 'Mugs, bowls and utensils', notes: 'Shared meal kit', group: '' },
     ]},
     { id: 'clothing', icon: '👕', name: 'Clothing', order: 4, items: [
-      { id: 'cl1', name: 'Cycling jerseys (×3)', weight: '', notes: 'Merino wool preferred', group: '' },
-      { id: 'cl2', name: 'Bib shorts / shorts (×2)', weight: '', notes: '', group: '' },
-      { id: 'cl3', name: 'Rain jacket', weight: '', notes: 'Lightweight packable', group: '' },
+      { id: 'cl1', name: 'Cycling jerseys (×3)', notes: 'Merino wool preferred', group: '' },
+      { id: 'cl2', name: 'Bib shorts / shorts (×2)', notes: '', group: '' },
+      { id: 'cl3', name: 'Rain jacket', notes: 'Lightweight packable', group: '' },
     ]},
     { id: 'nav-tech', icon: '📡', name: 'Navigation & Tech', order: 5, items: [
-      { id: 'nt1', name: 'GPS device', weight: '', notes: 'Garmin Edge', group: '' },
-      { id: 'nt2', name: 'Camera', weight: '', notes: '', group: '' },
-      { id: 'nt3', name: 'Laptop', weight: '', notes: 'For blog & work on the road', group: '' },
+      { id: 'nt1', name: 'GPS device', notes: 'Garmin Edge', group: '' },
+      { id: 'nt2', name: 'Camera', notes: '', group: '' },
+      { id: 'nt3', name: 'Laptop', notes: 'For blog & work on the road', group: '' },
     ]},
     { id: 'bike-maintenance', icon: '🔧', name: 'Bike Maintenance', order: 6, items: [
-      { id: 'bm1', name: 'Repair kit & multi-tool', weight: '', notes: '', group: '' },
-      { id: 'bm2', name: 'Spare tubes (×4)', weight: '', notes: '700×35c', group: '' },
+      { id: 'bm1', name: 'Repair kit & multi-tool', notes: '', group: '' },
+      { id: 'bm2', name: 'Spare tubes (×4)', notes: '700×35c', group: '' },
     ]},
     { id: 'extras', icon: '✨', name: 'Extras & Luxuries', order: 7, items: [
-      { id: 'ex1', name: 'Coffee dripper', weight: '', notes: '', group: '' },
-      { id: 'ex2', name: 'Small sketchbook', weight: '', notes: '', group: '' },
+      { id: 'ex1', name: 'Coffee dripper', notes: '', group: '' },
+      { id: 'ex2', name: 'Small sketchbook', notes: '', group: '' },
     ]},
   ];
 
@@ -619,11 +619,10 @@
         const groupEl  = row.querySelector('[data-field="group"]');
         if (!nameEl) return;
         items.push({
-          id:     row.dataset.itemId || uid(),
-          name:   nameEl.textContent.trim(),
-          notes:  notesEl ? notesEl.textContent.trim() : '',
-          weight: '',
-          group:  groupEl ? groupEl.value : '',
+          id:    row.dataset.itemId || uid(),
+          name:  nameEl.textContent.trim(),
+          notes: notesEl ? notesEl.textContent.trim() : '',
+          group: groupEl ? groupEl.value : '',
         });
       });
       cats.push({ id: catId, icon: icon.trim(), name: name.trim(), items });
@@ -647,7 +646,7 @@
     addItem(catId) {
       _gearData = collectFromDOM();
       const cat = _gearData.find(c => c.id === catId);
-      if (cat) cat.items.push({ id: uid(), name: 'New item', weight: '', notes: '', group: '' });
+      if (cat) cat.items.push({ id: uid(), name: 'New item', notes: '', group: '' });
       renderGear(_gearData, true);
     },
     addCategory() {


### PR DESCRIPTION
- Fix bike photos not loading: move loadBikeLinks() inside try block in
  init() so it runs after Firestore is confirmed ready
- Rework gear categories: rig items now have Bike/Mounts/Bags groups
  rendered as visual separators; bag items split into Shelter & Sleep,
  Cooking & Eating, Clothing, Navigation & Tech, Bike Maintenance,
  Extras & Luxuries
- Add ↑/↓ move buttons per item in edit mode on both gear.html and admin
- Remove Who column from admin gear table; weight summary simplified to
  a single total
- Remove Bike URL input fields from admin gear section (photos only)
- Relax isRevampedShape() check so new category IDs are preserved

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0166r4u1m3gr6RGMzKiQdzm3