### PR TITLE
Fix gear group headers and surface bike photo load errors

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -734,7 +734,11 @@
   // ── Init ──────────────────────────────────────────────────
   function isRevampedShape(data) {
     const ids = new Set((data || []).map(cat => cat.id));
-    return ids.has('mika-rig') && ids.has('tom-rig');
+    if (!ids.has('mika-rig') || !ids.has('tom-rig')) return false;
+    // Require that rig items have the group field (added in v2 of the schema).
+    // Without this, old Firestore data without groups would be used as-is.
+    const mikaRig = data.find(c => c.id === 'mika-rig');
+    return !!(mikaRig && mikaRig.items && mikaRig.items.some(i => 'group' in i));
   }
 
   async function init() {
@@ -797,7 +801,7 @@
           label.appendChild(a);
         }
       });
-    } catch (e) { /* non-critical */ }
+    } catch (e) { console.warn('Gear: bike photos failed to load:', e.message || e); }
   }
 
   init();


### PR DESCRIPTION
## Summary

- **Fix group headers not showing**: `isRevampedShape()` now checks that rig items carry a `group` field in addition to the category IDs. Old Firestore data seeded before the schema change had no `group` fields, so it passed the previous check and was used as-is — causing the Bike/Mounts/Bags separator rows to never appear. The stricter check forces a re-seed with the new defaults on next page load.

- **Surface bike photo errors**: The silent `catch (e) { /* non-critical */ }` in `loadBikeLinks()` is replaced with a `console.warn`, so any failure (Firestore permissions, missing document, invalid URL) is visible in the browser console for debugging.

---
_Generated by [Claude Code](https://claude.ai/code/session_0166r4u1m3gr6RGMzKiQdzm3)_