### PR TITLE
Split my-routes.pmtiles into per-trip shards to fix 100MB CI failure

### DIFF
--- a/.github/workflows/fetch-strava-rides.yml
+++ b/.github/workflows/fetch-strava-rides.yml
@@ -113,17 +113,23 @@ jobs:
         working-directory: scripts
         run: npm install
 
-      - name: Generate and upload PMTiles (my-routes + planned-routes)
+      - name: Generate and upload PMTiles (my-routes shards + planned-routes)
         working-directory: scripts
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          JAPAN_TRIP_FROM:      ${{ vars.JAPAN_TRIP_FROM }}
+          JAPAN_TRIP_TO:        ${{ vars.JAPAN_TRIP_TO }}
+          DENMARK_TRIP_FROM:    ${{ vars.DENMARK_TRIP_FROM }}
+          DENMARK_TRIP_TO:      ${{ vars.DENMARK_TRIP_TO }}
+          NORWAY_TRIP_FROM:     ${{ vars.NORWAY_TRIP_FROM }}
+          NORWAY_TRIP_TO:       ${{ vars.NORWAY_TRIP_TO }}
         run: node generate-pmtiles.js
 
       - name: Commit updated PMTiles to repo
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add assets/tiles/my-routes.pmtiles assets/tiles/planned-routes.pmtiles
+          git add assets/tiles/my-routes-*.pmtiles assets/tiles/my-routes-manifest.json assets/tiles/planned-routes.pmtiles
           git diff --cached --quiet || git commit -m "chore: update assets/tiles/*.pmtiles [skip ci]"
           git pull --rebase
           git push

--- a/.github/workflows/generate-tiles.yml
+++ b/.github/workflows/generate-tiles.yml
@@ -2,16 +2,26 @@
 #
 # Workflow: Generate PMTiles Tiles
 #
-# Regenerates two separate PMTiles files from all GPX files in Firebase Storage
-# and uploads the results to Firebase Storage:
-#   - tiles/my-routes.pmtiles      – personal/Strava routes (isOwner: true)
+# Regenerates PMTiles files from all GPX files in Firebase Storage and
+# uploads the results to Firebase Storage:
+#   - tiles/my-routes-<category>.pmtiles – personal/Strava routes (isOwner:
+#     true), split into bounded per-trip shards (japan/norway/denmark/
+#     other-<year>) so no single file grows past GitHub's 100 MB limit
 #   - tiles/planned-routes.pmtiles – manually uploaded planning routes
+#   - assets/tiles/my-routes-manifest.json – lists the shards generated
+#     this run so frontend pages can load them without a hardcoded list
 #
-# Both files are rendered as separate overlays on the planning.html map page.
+# All are rendered as overlays on the planning.html map page (and the
+# per-trip shards are grouped into a single "My Routes" overlay elsewhere).
 #
 # Required secrets (add in Settings > Secrets and variables > Actions):
 #   FIREBASE_SERVICE_ACCOUNT: JSON string of a Firebase service account key
 #     with Storage Object Admin permissions on the roots-eddf5 bucket.
+#
+# Optional repository variables (same as used by fetch-strava-rides.yml):
+#   JAPAN_TRIP_FROM / JAPAN_TRIP_TO
+#   NORWAY_TRIP_FROM / NORWAY_TRIP_TO
+#   DENMARK_TRIP_FROM / DENMARK_TRIP_TO
 #
 # Triggers:
 #   - Manual: Actions tab > "Generate PMTiles Tiles" > Run workflow
@@ -51,17 +61,23 @@ jobs:
         working-directory: scripts
         run: npm install
 
-      - name: Generate and upload PMTiles (my-routes + planned-routes)
+      - name: Generate and upload PMTiles (my-routes shards + planned-routes)
         working-directory: scripts
         env:
           FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          JAPAN_TRIP_FROM:      ${{ vars.JAPAN_TRIP_FROM }}
+          JAPAN_TRIP_TO:        ${{ vars.JAPAN_TRIP_TO }}
+          DENMARK_TRIP_FROM:    ${{ vars.DENMARK_TRIP_FROM }}
+          DENMARK_TRIP_TO:      ${{ vars.DENMARK_TRIP_TO }}
+          NORWAY_TRIP_FROM:     ${{ vars.NORWAY_TRIP_FROM }}
+          NORWAY_TRIP_TO:       ${{ vars.NORWAY_TRIP_TO }}
         run: node generate-pmtiles.js
 
       - name: Commit updated PMTiles to repo
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add assets/tiles/my-routes.pmtiles assets/tiles/planned-routes.pmtiles
+          git add assets/tiles/my-routes-*.pmtiles assets/tiles/my-routes-manifest.json assets/tiles/planned-routes.pmtiles
           git diff --cached --quiet || git commit -m "chore: update assets/tiles/*.pmtiles [skip ci]"
           git pull --rebase
           git push

--- a/js/denmark-map.js
+++ b/js/denmark-map.js
@@ -443,7 +443,31 @@
         });
     }
 
-    loadTile('my-routes.pmtiles',      'dk-my-routes',      'My Routes (tiles)',      true);
+    // My Routes is split into several per-trip shards (see
+    // scripts/generate-pmtiles.js) so no single file grows past GitHub's
+    // 100 MB limit. The manifest lists which shards exist; they're all
+    // grouped into one layer so the UI still shows a single "My Routes"
+    // toggle, same as before.
+    function loadMyRoutesShards() {
+      fetch('assets/tiles/my-routes-manifest.json').then(function (res) {
+        if (!res.ok) throw new Error('manifest fetch failed: ' + res.status);
+        return res.json();
+      }).then(function (manifest) {
+        var categories = (manifest && manifest.categories) || [];
+        return Promise.all(categories.map(function (category) {
+          return buildLayer('assets/tiles/my-routes-' + category + '.pmtiles', 'dk-my-routes-' + category);
+        }));
+      }).then(function (layers) {
+        if (layers.length === 0) return;
+        var group = L.layerGroup(layers);
+        layerControl.addOverlay(group, 'My Routes (tiles)');
+        group.addTo(map);
+      }).catch(function (err) {
+        console.warn('PMTiles layer "My Routes (tiles)" unavailable:', err && err.message || err);
+      });
+    }
+
+    loadMyRoutesShards();
     loadTile('planned-routes.pmtiles', 'dk-planned-routes', 'Planned Routes (tiles)', true);
   }
 

--- a/js/japan-map.js
+++ b/js/japan-map.js
@@ -348,7 +348,31 @@
       });
     }
 
-    loadTile('my-routes.pmtiles',       'my-routes',       'My Routes (tiles)',       true);
+    // My Routes is split into several per-trip shards (see
+    // scripts/generate-pmtiles.js) so no single file grows past GitHub's
+    // 100 MB limit. The manifest lists which shards exist; they're all
+    // grouped into one layer so the UI still shows a single "My Routes"
+    // toggle, same as before.
+    function loadMyRoutesShards() {
+      fetch('assets/tiles/my-routes-manifest.json').then(function(res) {
+        if (!res.ok) throw new Error('manifest fetch failed: ' + res.status);
+        return res.json();
+      }).then(function(manifest) {
+        const categories = (manifest && manifest.categories) || [];
+        return Promise.all(categories.map(function(category) {
+          return buildLayer('assets/tiles/my-routes-' + category + '.pmtiles', 'my-routes-' + category);
+        }));
+      }).then(function(layers) {
+        if (layers.length === 0) return;
+        const group = L.layerGroup(layers);
+        layerControl.addOverlay(group, 'My Routes (tiles)');
+        group.addTo(map);
+      }).catch(function(err) {
+        console.warn('PMTiles layer "My Routes (tiles)" unavailable:', err && err.message || err);
+      });
+    }
+
+    loadMyRoutesShards();
     loadTile('planned-routes.pmtiles',  'planned-routes',  'Planned Routes (tiles)',  false);
   }
 

--- a/js/norway-map.js
+++ b/js/norway-map.js
@@ -653,7 +653,31 @@
         });
     }
 
-    loadTile('my-routes.pmtiles',      'no-my-routes',      'My Routes (tiles)',      true);
+    // My Routes is split into several per-trip shards (see
+    // scripts/generate-pmtiles.js) so no single file grows past GitHub's
+    // 100 MB limit. The manifest lists which shards exist; they're all
+    // grouped into one layer so the UI still shows a single "My Routes"
+    // toggle, same as before.
+    function loadMyRoutesShards() {
+      fetch('assets/tiles/my-routes-manifest.json').then(function (res) {
+        if (!res.ok) throw new Error('manifest fetch failed: ' + res.status);
+        return res.json();
+      }).then(function (manifest) {
+        var categories = (manifest && manifest.categories) || [];
+        return Promise.all(categories.map(function (category) {
+          return buildLayer('assets/tiles/my-routes-' + category + '.pmtiles', 'no-my-routes-' + category);
+        }));
+      }).then(function (layers) {
+        if (layers.length === 0) return;
+        var group = L.layerGroup(layers);
+        layerControl.addOverlay(group, 'My Routes (tiles)');
+        group.addTo(map);
+      }).catch(function (err) {
+        console.warn('PMTiles layer "My Routes (tiles)" unavailable:', err && err.message || err);
+      });
+    }
+
+    loadMyRoutesShards();
     loadTile('planned-routes.pmtiles', 'no-planned-routes', 'Planned Routes (tiles)', true);
   }
 

--- a/js/route-map.js
+++ b/js/route-map.js
@@ -62,22 +62,24 @@
    *
    * @param {string} elementId  – id of the map <div>
    * @param {object} [options]
-   *   center   {number[]}  [lat, lng] map center    (default: central Japan)
-   *   zoom     {number}    initial zoom             (default: 5)
-   *   tilesUrl {string}    direct URL for my-routes.pmtiles
-   *   dateFrom {string}    ISO date string YYYY-MM-DD; only show rides on/after this date
-   *   dateTo   {string}    ISO date string YYYY-MM-DD; only show rides on/before this date
+   *   center      {number[]}  [lat, lng] map center    (default: central Japan)
+   *   zoom        {number}    initial zoom             (default: 5)
+   *   manifestUrl {string}    URL for the my-routes-manifest.json shard list
+   *   dateFrom    {string}    ISO date string YYYY-MM-DD; only show rides on/after this date
+   *   dateTo      {string}    ISO date string YYYY-MM-DD; only show rides on/before this date
    * @returns {L.Map} with an extra setTripFilter(dateFrom, dateTo) method
    */
   function init(elementId, options) {
     options = options || {};
-    var center   = options.center   || [36.5, 138];
-    var zoom     = options.zoom     || 5;
-    var tilesUrl = options.tilesUrl || 'assets/tiles/my-routes.pmtiles';
+    var center      = options.center      || [36.5, 138];
+    var zoom        = options.zoom        || 5;
+    var manifestUrl = options.manifestUrl || 'assets/tiles/my-routes-manifest.json';
 
-    // Unique PMTiles instance key per element avoids collisions when multiple
-    // maps are on the same page.
-    var instanceKey = 'route-map-' + elementId;
+    // Unique PMTiles instance key prefix per element avoids collisions when
+    // multiple maps are on the same page. My Routes is split into several
+    // per-trip shards (see scripts/generate-pmtiles.js) so each shard gets
+    // its own instance key, e.g. "route-map-<elementId>-japan".
+    var instanceKeyPrefix = 'route-map-' + elementId;
 
     var map = L.map(elementId, {
       renderer: L.canvas({ tolerance: 10 }),
@@ -96,54 +98,74 @@
     L.control.scale({ position: 'bottomright', imperial: false }).addTo(map);
 
     // ── Load route tiles via PMTiles + VectorGrid ─────────────────────────
-    var _header     = null;
-    var _routeLayer = null;
-    var _dateFrom   = options.dateFrom || null;
-    var _dateTo     = options.dateTo   || null;
+    // My Routes is split into several per-trip shards; the manifest lists
+    // which ones exist so this file never needs a hardcoded category list.
+    var _categories      = [];   // shard categories loaded from the manifest
+    var _headers         = {};   // category -> PMTiles header
+    var _routeLayerGroup = null; // group of all shard layers, one map entry
+    var _dateFrom        = options.dateFrom || null;
+    var _dateTo          = options.dateTo   || null;
+
+    function routeStyle(properties) {
+      if (_dateFrom || _dateTo) {
+        var filename = properties.filename || '';
+        var m = filename.match(/strava_\d+_(\d{4}-\d{2}-\d{2})_/);
+        if (!m) return { weight: 0, opacity: 0, fill: false };
+        var d = m[1];
+        if (_dateFrom && d < _dateFrom) return { weight: 0, opacity: 0, fill: false };
+        if (_dateTo   && d > _dateTo)   return { weight: 0, opacity: 0, fill: false };
+      }
+      return {
+        weight: getRouteWeight(map.getZoom()),
+        color: properties.color || '#E76F51',
+        opacity: 0.9,
+        fill: false
+      };
+    }
 
     function buildLayer() {
-      if (_routeLayer) { map.removeLayer(_routeLayer); _routeLayer = null; }
-      if (!_header) return;
+      if (_routeLayerGroup) { map.removeLayer(_routeLayerGroup); _routeLayerGroup = null; }
+      if (_categories.length === 0) return;
 
-      var gridOptions = {
-        vectorTileLayerStyles: {
-          routes: function (properties) {
-            if (_dateFrom || _dateTo) {
-              var filename = properties.filename || '';
-              var m = filename.match(/strava_\d+_(\d{4}-\d{2}-\d{2})_/);
-              if (!m) return { weight: 0, opacity: 0, fill: false };
-              var d = m[1];
-              if (_dateFrom && d < _dateFrom) return { weight: 0, opacity: 0, fill: false };
-              if (_dateTo   && d > _dateTo)   return { weight: 0, opacity: 0, fill: false };
-            }
-            return {
-              weight: getRouteWeight(map.getZoom()),
-              color: properties.color || '#E76F51',
-              opacity: 0.9,
-              fill: false
-            };
+      var layers = _categories.map(function (category) {
+        var header = _headers[category] || { minZoom: 2, maxZoom: 14 };
+        return L.vectorGrid.protobuf(
+          'pmtiles://' + instanceKeyPrefix + '-' + category + '/{z}/{x}/{y}',
+          {
+            vectorTileLayerStyles: { routes: routeStyle },
+            interactive: false,
+            updateWhenZooming: false,
+            keepBuffer: 4,
+            maxNativeZoom: header.maxZoom || 14,
+            minNativeZoom: header.minZoom || 2
           }
-        },
-        interactive: false,
-        updateWhenZooming: false,
-        keepBuffer: 4,
-        maxNativeZoom: _header.maxZoom || 14,
-        minNativeZoom: _header.minZoom || 2
-      };
+        );
+      });
 
-      _routeLayer = L.vectorGrid.protobuf(
-        'pmtiles://' + instanceKey + '/{z}/{x}/{y}',
-        gridOptions
-      );
-      _routeLayer.addTo(map);
+      _routeLayerGroup = L.layerGroup(layers);
+      _routeLayerGroup.addTo(map);
     }
 
     if (typeof pmtiles !== 'undefined' && typeof L.vectorGrid !== 'undefined') {
-      var pmInstance = new pmtiles.PMTiles(tilesUrl);
-      window.__pmtilesInstances[instanceKey] = pmInstance;
-
-      pmInstance.getHeader().then(function (header) {
-        _header = header;
+      fetch(manifestUrl).then(function (res) {
+        if (!res.ok) throw new Error('manifest fetch failed: ' + res.status);
+        return res.json();
+      }).then(function (manifest) {
+        var categories = (manifest && manifest.categories) || [];
+        return Promise.all(categories.map(function (category) {
+          var key = instanceKeyPrefix + '-' + category;
+          var p = new pmtiles.PMTiles('assets/tiles/my-routes-' + category + '.pmtiles');
+          window.__pmtilesInstances[key] = p;
+          return p.getHeader().then(function (header) {
+            _headers[category] = header;
+          }).catch(function () {
+            _headers[category] = { minZoom: 2, maxZoom: 14 };
+          }).then(function () {
+            return category;
+          });
+        }));
+      }).then(function (loadedCategories) {
+        _categories = loadedCategories || [];
         buildLayer();
       }).catch(function (err) {
         console.warn('RouteMap: could not load route tiles:', (err && err.message) || err || 'Unknown error');

--- a/planning.html
+++ b/planning.html
@@ -1195,10 +1195,12 @@
   });
 
   // ── PMTiles route layers ────────────────────────────────────
-  // Loads two separate PMTiles files from Firebase Storage:
-  //   my-routes.pmtiles      – personal/Strava routes (isOwner)
-  //   planned-routes.pmtiles – manually uploaded planning routes
-  // Each is added as a separate overlay in the layer control.
+  // Loads PMTiles files from Firebase Storage:
+  //   my-routes-<category>.pmtiles – personal/Strava routes (isOwner),
+  //     split into per-trip shards (see scripts/generate-pmtiles.js);
+  //     the manifest lists which shards exist, and they're grouped into
+  //     one "My Routes (tiles)" overlay in the layer control.
+  //   planned-routes.pmtiles       – manually uploaded planning routes
   function initPMTilesLayer() {
     if (typeof pmtiles === 'undefined' || typeof L.vectorGrid === 'undefined') return;
 
@@ -1269,14 +1271,42 @@
       });
     }
 
-    // Personal (Strava) routes — on by default
-    tryLoadTile(
-      'my-routes.pmtiles',
-      'my-routes',
-      'My Routes (tiles)',
-      'https://firebasestorage.googleapis.com/v0/b/roots-eddf5.firebasestorage.app/o/tiles%2Fmy-routes.pmtiles?alt=media',
-      true  // add to map by default
-    );
+    // Loads a single shard layer (Firebase Storage first, direct-URL fallback)
+    // without touching the layer control — the caller groups shards together.
+    function loadShardLayer(storageName, instanceKey, directUrl) {
+      const storagePromise = storage
+        ? storage.ref('tiles/' + storageName).getDownloadURL().then(function(url) { return buildLayer(url, instanceKey); })
+        : Promise.reject(new Error('storage not ready'));
+      return storagePromise.catch(function() {
+        return buildLayer(directUrl, instanceKey);
+      });
+    }
+
+    // Personal (Strava) routes — split into several per-trip shards (see
+    // scripts/generate-pmtiles.js) so no single file grows past GitHub's
+    // 100 MB limit. The manifest lists which shards exist; they're all
+    // grouped into one layer so the UI still shows a single "My Routes"
+    // toggle, on by default like before.
+    fetch('assets/tiles/my-routes-manifest.json').then(function(res) {
+      if (!res.ok) throw new Error('manifest fetch failed: ' + res.status);
+      return res.json();
+    }).then(function(manifest) {
+      const categories = (manifest && manifest.categories) || [];
+      return Promise.all(categories.map(function(category) {
+        return loadShardLayer(
+          'my-routes-' + category + '.pmtiles',
+          'my-routes-' + category,
+          'https://firebasestorage.googleapis.com/v0/b/roots-eddf5.firebasestorage.app/o/tiles%2Fmy-routes-' + category + '.pmtiles?alt=media'
+        );
+      }));
+    }).then(function(layers) {
+      if (layers.length === 0) return;
+      const group = L.layerGroup(layers);
+      layerControl.addOverlay(group, 'My Routes (tiles)');
+      group.addTo(map);
+    }).catch(function(err) {
+      console.warn('PMTiles layer "My Routes (tiles)" unavailable:', err && err.message || err);
+    });
 
     // Planned routes — off by default
     tryLoadTile(

--- a/scripts/generate-pmtiles.js
+++ b/scripts/generate-pmtiles.js
@@ -4,15 +4,29 @@
  * generate-pmtiles.js
  *
  * Downloads all GPX files from Firebase Storage (gpx/ prefix), converts them
- * to GeoJSON, and runs tippecanoe to generate two separate PMTiles files:
- *   - tiles/my-routes.pmtiles   – personal/Strava routes (isOwner: true)
+ * to GeoJSON, and runs tippecanoe to generate PMTiles files:
+ *   - tiles/my-routes-<category>.pmtiles – personal/Strava routes (isOwner:
+ *     true), split into bounded shards by trip so no single file grows
+ *     past GitHub's 100 MB limit. Category is one of 'japan', 'norway',
+ *     'denmark' (using the same JAPAN_TRIP_FROM/TO-style date windows as
+ *     fetch-strava-rides.js) or 'other-<year>' for anything outside those
+ *     windows.
  *   - tiles/planned-routes.pmtiles – manually uploaded planning routes
+ *   - assets/tiles/my-routes-manifest.json – lists the category shards
+ *     generated this run, so frontend pages can discover them without any
+ *     hardcoded list.
  *
- * Both files are uploaded back to Firebase Storage in the tiles/ prefix.
+ * All pmtiles files are uploaded back to Firebase Storage in the tiles/
+ * prefix and copied to assets/tiles/ for GitHub Pages serving.
  *
  * Usage:
  *   FIREBASE_SERVICE_ACCOUNT='<json>' node generate-pmtiles.js
  *   # or place serviceAccountKey.json in the same directory as this script
+ *
+ * Optional env vars (same names/format as fetch-strava-rides.js):
+ *   JAPAN_TRIP_FROM / JAPAN_TRIP_TO
+ *   NORWAY_TRIP_FROM / NORWAY_TRIP_TO
+ *   DENMARK_TRIP_FROM / DENMARK_TRIP_TO
  */
 
 const path = require('path');
@@ -61,6 +75,49 @@ const bucket = admin.storage().bucket();
 /** Returns true if a Firestore route document belongs to the owner (personal/Strava route). */
 function isOwnerDoc(data) {
   return !!(data.isOwner || data.source === 'strava');
+}
+
+// Matches the date segment in: strava_{id}_{YYYY-MM-DD}_{name}.gpx — same
+// convention used by fetch-strava-rides.js and route-map.js.
+const DATE_FROM_FILENAME_RE = /strava_\d+_(\d{4}-\d{2}-\d{2})_/;
+
+/**
+ * Returns the activity date (epoch ms) for a Firestore route doc, preferring
+ * the structured `activityDate` Timestamp field and falling back to parsing
+ * the date out of the file name for older/unbackfilled docs.
+ */
+function extractActivityMs(data) {
+  if (data.activityDate && typeof data.activityDate.toMillis === 'function') {
+    return data.activityDate.toMillis();
+  }
+  const candidate = data.fileName || (data.storagePath ? path.basename(data.storagePath) : '');
+  const m = candidate.match(DATE_FROM_FILENAME_RE);
+  if (!m) return null;
+  return new Date(m[1] + 'T00:00:00Z').getTime();
+}
+
+/** True if the given timestamp (ms) falls inside the <PREFIX>_TRIP_FROM/TO env window. */
+function isInTripWindow(activityMs, envPrefix) {
+  const fromEnv = process.env[`${envPrefix}_TRIP_FROM`];
+  if (!fromEnv) return false;
+  const fromMs = new Date(fromEnv).getTime();
+  const toEnv = process.env[`${envPrefix}_TRIP_TO`];
+  const toMs = toEnv ? new Date(toEnv).getTime() : Date.now();
+  return activityMs >= fromMs && activityMs <= toMs;
+}
+
+/**
+ * Classifies a personal route's activity date into a bounded pmtiles shard
+ * category: a named trip if it falls inside one of the JAPAN/NORWAY/DENMARK
+ * date windows, otherwise 'other-<year>' so the fallback bucket can't grow
+ * unbounded either. Returns 'other-unknown' if no date could be determined.
+ */
+function computeCategory(activityMs) {
+  if (activityMs == null) return 'other-unknown';
+  if (isInTripWindow(activityMs, 'JAPAN'))   return 'japan';
+  if (isInTripWindow(activityMs, 'DENMARK')) return 'denmark';
+  if (isInTripWindow(activityMs, 'NORWAY'))  return 'norway';
+  return `other-${new Date(activityMs).getUTCFullYear()}`;
 }
 
 /**
@@ -168,6 +225,9 @@ async function generateAndUpload(features, tmpDir, baseName, bucket) {
   //    -Z2              minimum zoom level 2
   //    --drop-densest-as-needed  thin points at lower zooms to keep tiles small
   //    --extend-zooms-if-still-dropping  add zoom levels until all features fit
+  //    --simplification=10  slightly more aggressive line simplification than
+  //                     tippecanoe's default, to keep output size down with
+  //                     negligible visual difference at normal viewing zooms
   //    -l routes        name the layer "routes" (referenced in planning.html)
   //    --force          overwrite output file if it already exists
   const outputPath = path.join(tmpDir, `${baseName}.pmtiles`);
@@ -177,6 +237,7 @@ async function generateAndUpload(features, tmpDir, baseName, bucket) {
     '-Z2',
     '--drop-densest-as-needed',
     '--extend-zooms-if-still-dropping',
+    '--simplification=10',
     '-l', 'routes',
     '-o', outputPath,
     '--force',
@@ -186,6 +247,21 @@ async function generateAndUpload(features, tmpDir, baseName, bucket) {
   console.log(`Running tippecanoe for ${baseName}...`);
   execSync(tippecanoeCmd, { stdio: 'inherit' });
   console.log(`Generated ${baseName}.pmtiles at: ${outputPath}`);
+
+  // Safety guard: fail loudly here, with an actionable message, rather than
+  // letting an oversized file reach `git push` and get rejected there.
+  // GitHub's hard limit is 100 MB; 90 MB leaves a safety margin.
+  const MAX_SAFE_BYTES = 90 * 1024 * 1024;
+  const outputSize = fs.statSync(outputPath).size;
+  console.log(`  ${baseName}.pmtiles size: ${(outputSize / (1024 * 1024)).toFixed(1)} MB`);
+  if (outputSize > MAX_SAFE_BYTES) {
+    throw new Error(
+      `${baseName}.pmtiles is ${(outputSize / (1024 * 1024)).toFixed(1)} MB, ` +
+      `exceeding the ${(MAX_SAFE_BYTES / (1024 * 1024)).toFixed(0)} MB safety threshold ` +
+      `(GitHub's hard limit is 100 MB). This shard needs a narrower trip window, an ` +
+      `additional split, or more simplification before it can be committed.`
+    );
+  }
 
   // Upload to Firebase Storage
   const destination = `tiles/${baseName}.pmtiles`;
@@ -238,7 +314,8 @@ async function main() {
         sourceUrl:   (data.metadata && data.metadata.sourceUrl) || null,
         gpxContent:  data.gpxContent || null, // backward-compat: legacy docs may have gpxContent cached inline
         storagePath: data.storagePath || null,
-        fileName:    data.fileName    || null
+        fileName:    data.fileName    || null,
+        category:    isOwner ? computeCategory(extractActivityMs(data)) : null
       };
       if (isOwner) {
         myRoutesMeta.push(meta);
@@ -278,7 +355,7 @@ async function main() {
     //    Route membership (personal vs planning) is determined by which colorMap
     //    contains the storagePath/fileName.
     const parser = new DOMParser();
-    const myFeatures   = [];
+    const myFeaturesByCategory = {}; // category -> feature array
     const planFeatures = [];
 
     // Determine if a storage file belongs to personal routes
@@ -287,13 +364,25 @@ async function main() {
       return !!(myColorMap[storagePath] || myColorMap[fileName]);
     }
 
+    function categoryForFile(storagePath) {
+      const fileName = path.basename(storagePath);
+      const meta = myColorMap[storagePath] || myColorMap[fileName];
+      return (meta && meta.category) || 'other-unknown';
+    }
+
+    function addToCategory(category, features) {
+      if (features.length === 0) return;
+      if (!myFeaturesByCategory[category]) myFeaturesByCategory[category] = [];
+      myFeaturesByCategory[category].push(...features);
+    }
+
     for (const file of gpxFiles) {
       console.log(`  Processing Storage file: ${file.name}`);
       try {
         const [content] = await file.download();
         const xmlStr = content.toString('utf8');
         if (isOwnerFile(file.name)) {
-          myFeatures.push(...gpxTextToFeatures(parser, xmlStr, file.name, null, myColorMap));
+          addToCategory(categoryForFile(file.name), gpxTextToFeatures(parser, xmlStr, file.name, null, myColorMap));
         } else {
           planFeatures.push(...gpxTextToFeatures(parser, xmlStr, file.name, null, planColorMap));
         }
@@ -324,7 +413,10 @@ async function main() {
     for (const r of myFirestoreOnly) {
       console.log(`  Processing Firestore-cached GPX (personal): ${r.fileName || '(unknown)'}`);
       try {
-        myFeatures.push(...gpxTextToFeatures(parser, r.gpxContent, r.storagePath, r.fileName, myColorMap));
+        addToCategory(
+          r.category || 'other-unknown',
+          gpxTextToFeatures(parser, r.gpxContent, r.storagePath, r.fileName, myColorMap)
+        );
       } catch (err) {
         console.warn(`  Warning: Failed to process inline gpxContent for ${r.fileName || '(unknown)'}:`, err.message);
       }
@@ -339,17 +431,30 @@ async function main() {
       }
     }
 
-    console.log(`Personal routes: ${myFeatures.length} GeoJSON feature(s).`);
+    const categories = Object.keys(myFeaturesByCategory).sort();
+    const myFeatureCount = categories.reduce((sum, c) => sum + myFeaturesByCategory[c].length, 0);
+    console.log(`Personal routes: ${myFeatureCount} GeoJSON feature(s) across ${categories.length} categor${categories.length === 1 ? 'y' : 'ies'}: ${categories.join(', ') || '(none)'}.`);
     console.log(`Planning routes: ${planFeatures.length} GeoJSON feature(s).`);
 
-    if (myFeatures.length === 0 && planFeatures.length === 0) {
+    if (myFeatureCount === 0 && planFeatures.length === 0) {
       console.warn('No valid GeoJSON features produced for either route set. Exiting without generating tiles.');
       return;
     }
 
-    // 4 & 5. Generate and upload separate PMTiles for each route type.
-    await generateAndUpload(myFeatures,   tmpDir, 'my-routes',      bucket);
+    // 4 & 5. Generate and upload one PMTiles shard per personal-route category,
+    // plus a single file for planned routes.
+    for (const category of categories) {
+      await generateAndUpload(myFeaturesByCategory[category], tmpDir, `my-routes-${category}`, bucket);
+    }
     await generateAndUpload(planFeatures, tmpDir, 'planned-routes', bucket);
+
+    // Write a manifest listing the shards generated this run, so frontend
+    // pages can discover them dynamically without any hardcoded category list.
+    const assetsDir = path.join(__dirname, '..', 'assets', 'tiles');
+    if (!fs.existsSync(assetsDir)) fs.mkdirSync(assetsDir, { recursive: true });
+    const manifestPath = path.join(assetsDir, 'my-routes-manifest.json');
+    fs.writeFileSync(manifestPath, JSON.stringify({ categories }, null, 2));
+    console.log(`Wrote manifest: ${manifestPath}`);
 
   } finally {
     // 6. Clean up temp directory


### PR DESCRIPTION
The nightly Strava sync fails because my-routes.pmtiles exceeds GitHub's
100MB file limit. Since all of this year's riding is one big multi-country
trip, generate-pmtiles.js now buckets personal routes by activity date
into japan/norway/denmark/other-<year> shards (reusing the JAPAN_TRIP_FROM/TO
etc. windows already used for stats), writes a manifest so consumers can
discover shards without hardcoding, and fails loudly if any shard exceeds
a safety threshold instead of letting git push reject it. Frontend map
pages now load all shards via the manifest and group them into one
existing "My Routes" toggle, so behavior is unchanged. Also bumped
tippecanoe simplification slightly to shrink output further.

Firebase Storage was considered as an alternative host (already used as a
fallback in planning.html), but was rejected after testing confirmed the
bucket has no CDN in front of it, matching previously observed ~30s load
times, so GitHub Pages remains the primary host.